### PR TITLE
Improve performance of waypoint reached logic (see #7)

### DIFF
--- a/urRobotApp/Db/waypointJ.db
+++ b/urRobotApp/Db/waypointJ.db
@@ -189,8 +189,14 @@ record(seq, "$(P)WaypointJ:$(N):Reset")
     field(LNK4, "$(P)WaypointJ:$(N):J5 PP")
     field(DOL5, "$(P)Receive:Joint6")
     field(LNK5, "$(P)WaypointJ:$(N):J6 PP")
+
     field(DOL6, "1")
-    field(LNK6, "$(P)WaypointJ:$(N):Reached.VAL PP")
+    field(LNK6, "$(P)waypoint_clear_reached.PROC")
+    field(DOL7, "$(N)")
+    field(LNK7, "$(P)waypoint_active_number.VAL PP")
+    field(DOL8, "J")
+    field(LNK8, "$(P)waypoint_active_type.VAL PP")
+
     field(FLNK, "$(P)WaypointJ:$(N):SetEnabled.PROC")
 }
 
@@ -247,7 +253,7 @@ record(seq, "$(P)WaypointJ:$(N):moveJ_seq1")
     field(LNK8, "$(P)waypoint_clear_reached.PROC")
     field(DOL9, "$(N)")
     field(LNK9, "$(P)waypoint_active_number.VAL PP")
-    field(DOLA, "L")
+    field(DOLA, "J")
     field(LNKA, "$(P)waypoint_active_type.VAL PP")
 
     field(FLNK, "$(P)WaypointJ:$(N):moveJ_seq2.PROC")

--- a/urRobotApp/Db/waypointJ.db
+++ b/urRobotApp/Db/waypointJ.db
@@ -156,20 +156,7 @@ record(stringin, "$(P)WaypointJ:$(N):ActionDesc")
     field(INP, "$(P)WaypointJ:$(N):get_action_desc.SVAL CP")
 }
 
-# # 1 if robot is at waypoint within tolerance, otherwise 0
-# record(luascript, "$(P)WaypointJ:$(N):Reached") {
-    # field(INPA, "$(P)Receive:Joint1")
-    # field(INPB, "$(P)Receive:Joint2")
-    # field(INPC, "$(P)Receive:Joint3")
-    # field(INPD, "$(P)Receive:Joint4")
-    # field(INPE, "$(P)Receive:Joint5")
-    # field(INPF, "$(P)Receive:Joint6")
-    # field(CODE, "@waypoints.lua waypointJ_reached({prefix='$(P)', N=$(N), tol=$(TOL=0.1)})")
-    # field(SCAN, ".1 second")
-    # field(OOPT, "On Change")
-    # field(PREC, 0)
-    # field(VAL, 0)
-# }
+# 1 if robot is at waypoint within tolerance, otherwise 0
 record(bi, "$(P)WaypointJ:$(N):Reached") {}
 
 # stores DOLx.VAL in LNKx.VAL
@@ -190,12 +177,12 @@ record(seq, "$(P)WaypointJ:$(N):Reset")
     field(DOL5, "$(P)Receive:Joint6")
     field(LNK5, "$(P)WaypointJ:$(N):J6 PP")
 
-    field(DOL6, "1")
+    field(DOL6, 1)
     field(LNK6, "$(P)waypoint_clear_reached.PROC")
-    field(DOL7, "$(N)")
-    field(LNK7, "$(P)waypoint_active_number.VAL PP")
-    field(DOL8, "J")
-    field(LNK8, "$(P)waypoint_active_type.VAL PP")
+    field(DOL7, 0)
+    field(LNK7, "$(P)waypoint_active_type.VAL PP")
+    field(DOL8, "$(N)")
+    field(LNK8, "$(P)waypoint_active_number.VAL PP")
 
     field(FLNK, "$(P)WaypointJ:$(N):SetEnabled.PROC")
 }
@@ -251,10 +238,10 @@ record(seq, "$(P)WaypointJ:$(N):moveJ_seq1")
 
     field(DOL8, "1")
     field(LNK8, "$(P)waypoint_clear_reached.PROC")
-    field(DOL9, "$(N)")
-    field(LNK9, "$(P)waypoint_active_number.VAL PP")
-    field(DOLA, "J")
-    field(LNKA, "$(P)waypoint_active_type.VAL PP")
+    field(DOL9, 0)
+    field(LNK9, "$(P)waypoint_active_type.VAL PP")
+    field(DOLA, "$(N)")
+    field(LNKA, "$(P)waypoint_active_number.VAL PP")
 
     field(FLNK, "$(P)WaypointJ:$(N):moveJ_seq2.PROC")
 }

--- a/urRobotApp/Db/waypointJ.db
+++ b/urRobotApp/Db/waypointJ.db
@@ -156,20 +156,21 @@ record(stringin, "$(P)WaypointJ:$(N):ActionDesc")
     field(INP, "$(P)WaypointJ:$(N):get_action_desc.SVAL CP")
 }
 
-# 1 if robot is at waypoint within tolerance, otherwise 0
-record(luascript, "$(P)WaypointJ:$(N):Reached") {
-    field(INPA, "$(P)Receive:Joint1")
-    field(INPB, "$(P)Receive:Joint2")
-    field(INPC, "$(P)Receive:Joint3")
-    field(INPD, "$(P)Receive:Joint4")
-    field(INPE, "$(P)Receive:Joint5")
-    field(INPF, "$(P)Receive:Joint6")
-    field(CODE, "@waypoints.lua waypointJ_reached({prefix='$(P)', N=$(N), tol=$(TOL=0.1)})")
-    field(SCAN, ".1 second")
-    field(OOPT, "On Change")
-    field(PREC, 0)
-    field(VAL, 0)
-}
+# # 1 if robot is at waypoint within tolerance, otherwise 0
+# record(luascript, "$(P)WaypointJ:$(N):Reached") {
+    # field(INPA, "$(P)Receive:Joint1")
+    # field(INPB, "$(P)Receive:Joint2")
+    # field(INPC, "$(P)Receive:Joint3")
+    # field(INPD, "$(P)Receive:Joint4")
+    # field(INPE, "$(P)Receive:Joint5")
+    # field(INPF, "$(P)Receive:Joint6")
+    # field(CODE, "@waypoints.lua waypointJ_reached({prefix='$(P)', N=$(N), tol=$(TOL=0.1)})")
+    # field(SCAN, ".1 second")
+    # field(OOPT, "On Change")
+    # field(PREC, 0)
+    # field(VAL, 0)
+# }
+record(bi, "$(P)WaypointJ:$(N):Reached") {}
 
 # stores DOLx.VAL in LNKx.VAL
 # Requires that RTDE Receive databases have been loaded
@@ -188,6 +189,8 @@ record(seq, "$(P)WaypointJ:$(N):Reset")
     field(LNK4, "$(P)WaypointJ:$(N):J5 PP")
     field(DOL5, "$(P)Receive:Joint6")
     field(LNK5, "$(P)WaypointJ:$(N):J6 PP")
+    field(DOL6, "1")
+    field(LNK6, "$(P)WaypointJ:$(N):Reached.VAL PP")
     field(FLNK, "$(P)WaypointJ:$(N):SetEnabled.PROC")
 }
 
@@ -239,6 +242,13 @@ record(seq, "$(P)WaypointJ:$(N):moveJ_seq1")
 
     field(DOL7, "1")
     field(LNK7, "$(P)WaypointJ:$(N):Busy PP")
+
+    field(DOL8, "1")
+    field(LNK8, "$(P)waypoint_clear_reached.PROC")
+    field(DOL9, "$(N)")
+    field(LNK9, "$(P)waypoint_active_number.VAL PP")
+    field(DOLA, "L")
+    field(LNKA, "$(P)waypoint_active_type.VAL PP")
 
     field(FLNK, "$(P)WaypointJ:$(N):moveJ_seq2.PROC")
 }

--- a/urRobotApp/Db/waypointL.db
+++ b/urRobotApp/Db/waypointL.db
@@ -189,6 +189,14 @@ record(seq, "$(P)WaypointL:$(N):Reset")
     field(LNK4, "$(P)WaypointL:$(N):Pitch PP")
     field(DOL5, "$(P)Receive:PoseYaw")
     field(LNK5, "$(P)WaypointL:$(N):Yaw PP")
+
+    field(DOL6, "1")
+    field(LNK6, "$(P)waypoint_clear_reached.PROC")
+    field(DOL7, "$(N)")
+    field(LNK7, "$(P)waypoint_active_number.VAL PP")
+    field(DOL8, "L")
+    field(LNK8, "$(P)waypoint_active_type.VAL PP")
+
     field(FLNK, "$(P)WaypointL:$(N):SetEnabled.PROC")
 }
 
@@ -245,7 +253,7 @@ record(seq, "$(P)WaypointL:$(N):moveL_seq1")
     field(LNK8, "$(P)waypoint_clear_reached.PROC")
     field(DOL9, "$(N)")
     field(LNK9, "$(P)waypoint_active_number.VAL PP")
-    field(DOLA, "J")
+    field(DOLA, "L")
     field(LNKA, "$(P)waypoint_active_type.VAL PP")
 
     field(FLNK, "$(P)WaypointL:$(N):moveL_seq2.PROC")

--- a/urRobotApp/Db/waypointL.db
+++ b/urRobotApp/Db/waypointL.db
@@ -155,21 +155,7 @@ record(stringin, "$(P)WaypointL:$(N):ActionDesc")
     field(INP, "$(P)WaypointL:$(N):get_action_desc.SVAL CP")
 }
 
-# # 1 if robot is at waypoint within tolerance, otherwise 0
-# record(luascript, "$(P)WaypointL:$(N):Reached") {
-    # field(INPA, "$(P)Receive:PoseX")
-    # field(INPB, "$(P)Receive:PoseY")
-    # field(INPC, "$(P)Receive:PoseZ")
-    # field(INPD, "$(P)Receive:PoseRoll")
-    # field(INPE, "$(P)Receive:PosePitch")
-    # field(INPF, "$(P)Receive:PoseYaw")
-    # field(CODE, "@waypoints.lua waypointL_reached({prefix='$(P)', N=$(N)})")
-    # field(SCAN, ".1 second")
-    # field(OOPT, "On Change")
-    # field(PREC, 0)
-    # field(VAL, 0)
-# }
-
+# 1 if robot is at waypoint within tolerance, otherwise 0
 record(bi, "$(P)WaypointL:$(N):Reached") {}
 
 # stores DOLx.VAL in LNKx.VAL
@@ -190,12 +176,12 @@ record(seq, "$(P)WaypointL:$(N):Reset")
     field(DOL5, "$(P)Receive:PoseYaw")
     field(LNK5, "$(P)WaypointL:$(N):Yaw PP")
 
-    field(DOL6, "1")
+    field(DOL6, 1)
     field(LNK6, "$(P)waypoint_clear_reached.PROC")
-    field(DOL7, "$(N)")
-    field(LNK7, "$(P)waypoint_active_number.VAL PP")
-    field(DOL8, "L")
-    field(LNK8, "$(P)waypoint_active_type.VAL PP")
+    field(DOL7, 1)
+    field(LNK7, "$(P)waypoint_active_type.VAL PP")
+    field(DOL8, "$(N)")
+    field(LNK8, "$(P)waypoint_active_number.VAL PP")
 
     field(FLNK, "$(P)WaypointL:$(N):SetEnabled.PROC")
 }
@@ -249,12 +235,12 @@ record(seq, "$(P)WaypointL:$(N):moveL_seq1")
     field(DOL7, "1")
     field(LNK7, "$(P)WaypointL:$(N):Busy PP")
 
-    field(DOL8, "1")
+    field(DOL8, 1)
     field(LNK8, "$(P)waypoint_clear_reached.PROC")
-    field(DOL9, "$(N)")
-    field(LNK9, "$(P)waypoint_active_number.VAL PP")
-    field(DOLA, "L")
-    field(LNKA, "$(P)waypoint_active_type.VAL PP")
+    field(DOL9, 1)
+    field(LNK9, "$(P)waypoint_active_type.VAL PP")
+    field(DOLA, "$(N)")
+    field(LNKA, "$(P)waypoint_active_number.VAL PP")
 
     field(FLNK, "$(P)WaypointL:$(N):moveL_seq2.PROC")
 }

--- a/urRobotApp/Db/waypointL.db
+++ b/urRobotApp/Db/waypointL.db
@@ -155,20 +155,22 @@ record(stringin, "$(P)WaypointL:$(N):ActionDesc")
     field(INP, "$(P)WaypointL:$(N):get_action_desc.SVAL CP")
 }
 
-# 1 if robot is at waypoint within tolerance, otherwise 0
-record(luascript, "$(P)WaypointL:$(N):Reached") {
-    field(INPA, "$(P)Receive:PoseX")
-    field(INPB, "$(P)Receive:PoseY")
-    field(INPC, "$(P)Receive:PoseZ")
-    field(INPD, "$(P)Receive:PoseRoll")
-    field(INPE, "$(P)Receive:PosePitch")
-    field(INPF, "$(P)Receive:PoseYaw")
-    field(CODE, "@waypoints.lua waypointL_reached({prefix='$(P)', N=$(N)})")
-    field(SCAN, ".1 second")
-    field(OOPT, "On Change")
-    field(PREC, 0)
-    field(VAL, 0)
-}
+# # 1 if robot is at waypoint within tolerance, otherwise 0
+# record(luascript, "$(P)WaypointL:$(N):Reached") {
+    # field(INPA, "$(P)Receive:PoseX")
+    # field(INPB, "$(P)Receive:PoseY")
+    # field(INPC, "$(P)Receive:PoseZ")
+    # field(INPD, "$(P)Receive:PoseRoll")
+    # field(INPE, "$(P)Receive:PosePitch")
+    # field(INPF, "$(P)Receive:PoseYaw")
+    # field(CODE, "@waypoints.lua waypointL_reached({prefix='$(P)', N=$(N)})")
+    # field(SCAN, ".1 second")
+    # field(OOPT, "On Change")
+    # field(PREC, 0)
+    # field(VAL, 0)
+# }
+
+record(bi, "$(P)WaypointL:$(N):Reached") {}
 
 # stores DOLx.VAL in LNKx.VAL
 # Requires that RTDE Receive databases have been loaded
@@ -238,6 +240,13 @@ record(seq, "$(P)WaypointL:$(N):moveL_seq1")
 
     field(DOL7, "1")
     field(LNK7, "$(P)WaypointL:$(N):Busy PP")
+
+    field(DOL8, "1")
+    field(LNK8, "$(P)waypoint_clear_reached.PROC")
+    field(DOL9, "$(N)")
+    field(LNK9, "$(P)waypoint_active_number.VAL PP")
+    field(DOLA, "J")
+    field(LNKA, "$(P)waypoint_active_type.VAL PP")
 
     field(FLNK, "$(P)WaypointL:$(N):moveL_seq2.PROC")
 }

--- a/urRobotApp/Db/waypoint_reached.db
+++ b/urRobotApp/Db/waypoint_reached.db
@@ -1,0 +1,41 @@
+record(bo, "$(P)waypoint_active_type")
+{
+    field(ZNAM, "J")
+    field(ONAM, "L")
+    field(VAL, 0)
+}
+
+record(longout, "$(P)waypoint_active_number")
+{
+    field(VAL, 0)
+}
+
+record(calcout, "$(P)trigger_reached_scan") {
+    field(INPA, "$(P)waypoint_active_number.VAL CP")
+    field(CALC, "A <= 0 ? 0 : 9")
+    field(OUT, "$(P)waypoint_active_reached.SCAN")
+}
+
+record(printf, "$(P)waypoint_reached_pv")
+{
+    field(INP0, "$(P)waypoint_active_type.VAL CP")
+    field(INP1, "$(P)waypoint_active_number.VAL CP")
+    field(FMT, "$(P)Waypoint%s:%d:Reached")
+}
+
+record(luascript, "$(P)waypoint_active_reached")
+{
+    field(INPA, "$(P)waypoint_active_type.VAL")
+    field(INPB, "$(P)waypoint_active_number.VAL")
+    field(INAA, "$(P)waypoint_reached_pv")
+    field(CODE, "@waypoints.lua active_reached({prefix='$(P)'})")
+    # field(SCAN, ".1 second")
+    field(OOPT, "On Change")
+}
+
+record(luascript, "$(P)waypoint_clear_reached")
+{
+    field(INPA, "$(P)waypoint_active_number.VAL")
+    field(INAA, "$(P)waypoint_reached_pv")
+    field(CODE, "@waypoints.lua clear_reached()")
+}

--- a/urRobotApp/Db/waypoint_reached.db
+++ b/urRobotApp/Db/waypoint_reached.db
@@ -29,7 +29,7 @@ record(luascript, "$(P)waypoint_active_reached")
     field(INPB, "$(P)waypoint_active_number.VAL")
     field(INAA, "$(P)waypoint_reached_pv")
     field(CODE, "@waypoints.lua active_reached({prefix='$(P)'})")
-    # field(SCAN, ".1 second")
+    field(SCAN, "Passive")
     field(OOPT, "On Change")
 }
 

--- a/urRobotApp/iocsh/load_waypoints.lua
+++ b/urRobotApp/iocsh/load_waypoints.lua
@@ -3,3 +3,4 @@ for n = 1, tonumber(N) do
     dbLoadRecords("$(URROBOT)/urRobotApp/Db/waypointJ.db", macros)
     dbLoadRecords("$(URROBOT)/urRobotApp/Db/waypointL.db", macros)
 end
+dbLoadRecords("$(URROBOT)/urRobotApp/Db/waypoint_reached.db", "P="..P)

--- a/urRobotApp/src/lua/waypoints.lua
+++ b/urRobotApp/src/lua/waypoints.lua
@@ -2,7 +2,7 @@
 epics = require("epics")
 
 -- Returns true if two numbers are within the specified tolerance of each other
-function almost_equal(a, b, tol)
+local function almost_equal(a, b, tol)
     tol = tol or 1e-6
     if (math.abs(a - b) <= tol) then
         return true
@@ -24,42 +24,6 @@ function table.almost_equal(t1, t2, tol)
     end
     return true
 end
-
--- -- TODO: Make PVs for tolerance
--- function waypointJ_reached(args)
-    -- local actual_pose = {A, B, C, D, E, F}
-    -- local waypoint_base = string.format("%sWaypointJ:%s", args.prefix, args.N)
-    -- local waypoint_pose = {
-        -- epics.get(string.format("%s:J1",waypoint_base)),
-        -- epics.get(string.format("%s:J2",waypoint_base)),
-        -- epics.get(string.format("%s:J3",waypoint_base)),
-        -- epics.get(string.format("%s:J4",waypoint_base)),
-        -- epics.get(string.format("%s:J5",waypoint_base)),
-        -- epics.get(string.format("%s:J6",waypoint_base))
-    -- }
-    -- local reached = table.almost_equal(waypoint_pose, actual_pose, args.tol)
-    -- return reached and 1 or 0
--- end
---
--- function waypointL_reached(args)
-    -- local actual_pose_xyz = {A, B, C}
-    -- local actual_pose_rpy = {D, E, F}
-    -- local waypoint_base = string.format("%sWaypointL:%s", args.prefix, args.N)
-    -- local waypoint_pose_xyz = {
-        -- epics.get(string.format("%s:X",waypoint_base)),
-        -- epics.get(string.format("%s:Y",waypoint_base)),
-        -- epics.get(string.format("%s:Z",waypoint_base)),
-    -- }
-    -- local waypoint_pose_rpy = {
-        -- epics.get(string.format("%s:Roll",waypoint_base)),
-        -- epics.get(string.format("%s:Pitch",waypoint_base)),
-        -- epics.get(string.format("%s:Yaw",waypoint_base))
-    -- }
---
-    -- local reached1 = table.almost_equal(waypoint_pose_xyz, actual_pose_xyz, 1.0)
-    -- local reached2 = table.almost_equal(waypoint_pose_rpy, actual_pose_rpy, 0.1)
-    -- return (reached1 and reached2) and 1 or 0
--- end
 
 local function joint_waypoint_reached(prefix, num)
     local actual_pose = {

--- a/urRobotApp/src/lua/waypoints.lua
+++ b/urRobotApp/src/lua/waypoints.lua
@@ -25,10 +25,53 @@ function table.almost_equal(t1, t2, tol)
     return true
 end
 
--- TODO: Make PVs for tolerance
-function waypointJ_reached(args)
-    local actual_pose = {A, B, C, D, E, F}
-    local waypoint_base = string.format("%sWaypointJ:%s", args.prefix, args.N)
+-- -- TODO: Make PVs for tolerance
+-- function waypointJ_reached(args)
+    -- local actual_pose = {A, B, C, D, E, F}
+    -- local waypoint_base = string.format("%sWaypointJ:%s", args.prefix, args.N)
+    -- local waypoint_pose = {
+        -- epics.get(string.format("%s:J1",waypoint_base)),
+        -- epics.get(string.format("%s:J2",waypoint_base)),
+        -- epics.get(string.format("%s:J3",waypoint_base)),
+        -- epics.get(string.format("%s:J4",waypoint_base)),
+        -- epics.get(string.format("%s:J5",waypoint_base)),
+        -- epics.get(string.format("%s:J6",waypoint_base))
+    -- }
+    -- local reached = table.almost_equal(waypoint_pose, actual_pose, args.tol)
+    -- return reached and 1 or 0
+-- end
+--
+-- function waypointL_reached(args)
+    -- local actual_pose_xyz = {A, B, C}
+    -- local actual_pose_rpy = {D, E, F}
+    -- local waypoint_base = string.format("%sWaypointL:%s", args.prefix, args.N)
+    -- local waypoint_pose_xyz = {
+        -- epics.get(string.format("%s:X",waypoint_base)),
+        -- epics.get(string.format("%s:Y",waypoint_base)),
+        -- epics.get(string.format("%s:Z",waypoint_base)),
+    -- }
+    -- local waypoint_pose_rpy = {
+        -- epics.get(string.format("%s:Roll",waypoint_base)),
+        -- epics.get(string.format("%s:Pitch",waypoint_base)),
+        -- epics.get(string.format("%s:Yaw",waypoint_base))
+    -- }
+--
+    -- local reached1 = table.almost_equal(waypoint_pose_xyz, actual_pose_xyz, 1.0)
+    -- local reached2 = table.almost_equal(waypoint_pose_rpy, actual_pose_rpy, 0.1)
+    -- return (reached1 and reached2) and 1 or 0
+-- end
+
+local function joint_waypoint_reached(prefix, num)
+    local actual_pose = {
+        epics.get(string.format("%sReceive:Joint1", prefix)),
+        epics.get(string.format("%sReceive:Joint2", prefix)),
+        epics.get(string.format("%sReceive:Joint3", prefix)),
+        epics.get(string.format("%sReceive:Joint4", prefix)),
+        epics.get(string.format("%sReceive:Joint5", prefix)),
+        epics.get(string.format("%sReceive:Joint6", prefix)),
+    }
+
+    local waypoint_base = string.format("%sWaypointJ:%d", prefix, num)
     local waypoint_pose = {
         epics.get(string.format("%s:J1",waypoint_base)),
         epics.get(string.format("%s:J2",waypoint_base)),
@@ -37,26 +80,59 @@ function waypointJ_reached(args)
         epics.get(string.format("%s:J5",waypoint_base)),
         epics.get(string.format("%s:J6",waypoint_base))
     }
-    local reached = table.almost_equal(waypoint_pose, actual_pose, args.tol)
+
+    local reached = table.almost_equal(waypoint_pose, actual_pose, 0.1)
     return reached and 1 or 0
 end
 
-function waypointL_reached(args)
-    local actual_pose_xyz = {A, B, C}
-    local actual_pose_rpy = {D, E, F}
-    local waypoint_base = string.format("%sWaypointL:%s", args.prefix, args.N)
-    local waypoint_pose_xyz = {
-        epics.get(string.format("%s:X",waypoint_base)),
-        epics.get(string.format("%s:Y",waypoint_base)),
-        epics.get(string.format("%s:Z",waypoint_base)),
+local function cartesian_waypoint_reached(prefix, num)
+    local actual_xyz = {
+        epics.get(string.format("%sReceive:PoseX", prefix)),
+        epics.get(string.format("%sReceive:PoseY", prefix)),
+        epics.get(string.format("%sReceive:PoseZ", prefix)),
     }
-    local waypoint_pose_rpy = {
-        epics.get(string.format("%s:Roll",waypoint_base)),
-        epics.get(string.format("%s:Pitch",waypoint_base)),
-        epics.get(string.format("%s:Yaw",waypoint_base))
+    local actual_rpy = {
+        epics.get(string.format("%sReceive:PoseRoll", prefix)),
+        epics.get(string.format("%sReceive:PosePitch", prefix)),
+        epics.get(string.format("%sReceive:PoseYaw", prefix)),
     }
+    local waypoint_base = string.format("%sWaypointL:%d", prefix, num)
+    local waypoint_xyz = {
+        epics.get(string.format("%s:X", waypoint_base)),
+        epics.get(string.format("%s:Y", waypoint_base)),
+        epics.get(string.format("%s:Z", waypoint_base)),
+    }
+    local waypoint_rpy = {
+        epics.get(string.format("%s:Roll", waypoint_base)),
+        epics.get(string.format("%s:Pitch", waypoint_base)),
+        epics.get(string.format("%s:Yaw", waypoint_base)),
+    }
+    local reached_xyz = table.almost_equal(waypoint_xyz, actual_xyz, 1.0)
+    local reached_rpy = table.almost_equal(waypoint_rpy, actual_rpy, 0.1)
+    return (reached_xyz and reached_rpy) and 1 or 0
+end
 
-    local reached1 = table.almost_equal(waypoint_pose_xyz, actual_pose_xyz, 1.0)
-    local reached2 = table.almost_equal(waypoint_pose_rpy, actual_pose_rpy, 0.1)
-    return (reached1 and reached2) and 1 or 0
+function active_reached(args)
+    local wp_type = A
+    local wp_num = B
+    local wp_reached_pv = AA
+
+    if wp_num <= 0 then return 0 end
+
+    local reached = 0
+    if wp_type == 0 then
+        reached = joint_waypoint_reached(args.prefix, wp_num)
+    else
+        reached = cartesian_waypoint_reached(args.prefix, wp_num)
+    end
+    epics.put(wp_reached_pv, reached)
+
+    return reached
+end
+
+function clear_reached()
+    local wp_num = A
+    if wp_num <= 0 then return end
+    local wp_reached_pv = AA
+    epics.put(wp_reached_pv, 0)
 end


### PR DESCRIPTION
As described in #7, we are unnecessarily polling the "Reached" record (e.g. WaypointJ:1:Reached) for every waypoint at 10Hz when really only 1 waypoint is "active" at a time.

This PR addresses this by adding waypoint_reached.db which contains logic to check if a single waypoint is reached. Which waypoint we check is set by the waypointL and waypointJ databases when moves are executed or the Reset records process (e.g. WaypointJ:1:Reset).

This reduces the number of 10Hz polling loops from N to 1 where N is the total number of waypoints (default 60). Though theoretically this sounds like a big performance improvement, a rudimentary comparison of CPU usage with `htop` does not show much difference.