### PR TITLE
Add Cartesian jogging support

### DIFF
--- a/docs/pv_reference_guide.md
+++ b/docs/pv_reference_guide.md
@@ -225,6 +225,30 @@ robot controller, `caput Dashboard:Play 1` and `caput Dashboard:Play.PROC 1` (an
 
 ***
 
+## rtde_control_jog.db
+
+***Inputs***
+
+| Record  | Type   | Description   |
+|-------------- | -------------- | -------------- |
+| Control:Jogging    | bi     | "Jogging" while jog is active, "Stopped" otherwise     |
+
+***Outputs***
+
+| Record  | Type   | Description   |
+|-------------- | -------------- | -------------- |
+| Control:JogStart    | bo     | Starts jogging with the current speed vector; resets watchdog timer     |
+| Control:JogStop    | bo     | Stops jogging     |
+| Control:JogAccel    | ao     | Jog acceleration (m/s/s, default 0.5)     |
+| Control:JogSpeedX    | ao     | Jog speed in X (mm/s)     |
+| Control:JogSpeedY    | ao     | Jog speed in Y (mm/s)     |
+| Control:JogSpeedZ    | ao     | Jog speed in Z (mm/s)     |
+| Control:JogSpeedRoll    | ao     | Jog speed in roll (deg/s)     |
+| Control:JogSpeedPitch    | ao     | Jog speed in pitch (deg/s)     |
+| Control:JogSpeedYaw    | ao     | Jog speed in yaw (deg/s)     |
+
+***
+
 ## rtde_io.db
 
 ***Outputs***

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,6 +96,44 @@ Once the safety event is cleared (e.g. the protective stop is unlocked via the t
 `$(P)Control:ReuploadControlScript` to reconnect the RTDE control interface before commanding
 further motion.
 
+### Jogging (Advanced)
+
+Jogging provides continuous velocity-based motion in Cartesian space. Unlike
+moveJ/moveL which move to a target position and stop, jogging moves the robot
+at a specified speed until explicitly stopped. This is useful for joystick or
+gamepad control.
+
+Jogging is an advanced feature that requires a specialized EPICS client. The
+client must repeatedly process `$(P)Control:JogStart` to keep the robot
+moving. An internal watchdog timer with a 1 second timeout will automatically
+stop the robot if `JogStart` is not processed in time. Standard MEDM/caQtDM
+screens are not well suited for this. An example client implementation could
+have buttons for jogging, where pressing and holding a button sets a speed
+vector and executes a caput to `JogStart` repeatedly, and `JogStop` is sent
+automatically on button release.
+
+The jog database (`rtde_control_jog.db`) is not loaded by `urRobot.iocsh` and
+must be loaded separately by the user:
+```
+dbLoadRecords("$(URROBOT)/db/rtde_control_jog.db", "P=$(PREFIX), PORT=rtde_ctrl")
+```
+
+#### Steps
+
+1. Set the desired speed vector by writing to the jog speed PVs
+   (`JogSpeedX`, `JogSpeedY`, `JogSpeedZ` in mm/s;
+   `JogSpeedRoll`, `JogSpeedPitch`, `JogSpeedYaw` in deg/s).
+2. Set the acceleration with `$(P)Control:JogAccel` (m/s/s, default 0.5).
+3. Process `$(P)Control:JogStart` to begin motion.
+4. **Continue processing `JogStart` periodically** to keep the robot moving.
+   If the speed PVs have changed since the last call, the new speeds are
+   sent to the robot.
+5. Process `$(P)Control:JogStop` to stop motion.
+
+Jog motion is in the robot base frame. The `$(P)Control:Jogging` PV indicates
+whether the robot is currently jogging.
+
+
 ## Robotiq Gripper
 
 Currently the Robotiq Hand-E gripper is the only supported gripper in this EPICS module, howevever other grippers

--- a/urRobotApp/Db/rtde_control_jog.db
+++ b/urRobotApp/Db/rtde_control_jog.db
@@ -1,0 +1,147 @@
+record(bi, "$(P)Control:Jogging") {
+    field(DTYP, "asynInt32")
+    field(INP, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOGGING")
+    field(ZNAM, "Stopped")
+    field(ONAM, "Jogging")
+    field(SCAN, "I/O Intr")
+}
+
+record(bo, "$(P)Control:JogStart") {
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_START")
+    field(FLNK, "$(P)Control:jog_timer:set_start.PROC")
+}
+
+record(bo, "$(P)Control:JogStop") {
+    field(DTYP, "asynInt32")
+    field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_STOP")
+}
+
+record(ao, "$(P)Control:JogAccel") {
+    field(DTYP, "asynFloat64")
+    field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_ACCELERATION")
+}
+
+record(bo, "$(P)Control:JogFeature") {
+    field(DTYP, "asynInt32")
+    field(VAL, 0)
+    field(ZNAM, "Base")
+    field(ONAM, "Tool")
+    field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_FEATURE")
+}
+
+record(ao, "$(P)Control:JogSpeed1") {
+    field(DTYP, "asynFloat64")
+    field(OUT, "@asyn($(PORT),0,$(TIMEOUT=1))JOG_SPEED")
+    field(PINI, "YES")
+    field(VAL, 0.0)
+    field(PREC, 4)
+}
+record(ao, "$(P)Control:JogSpeed2") {
+    field(DTYP, "asynFloat64")
+    field(OUT, "@asyn($(PORT),1,$(TIMEOUT=1))JOG_SPEED")
+    field(PINI, "YES")
+    field(VAL, 0.0)
+    field(PREC, 4)
+}
+record(ao, "$(P)Control:JogSpeed3") {
+    field(DTYP, "asynFloat64")
+    field(OUT, "@asyn($(PORT),2,$(TIMEOUT=1))JOG_SPEED")
+    field(PINI, "YES")
+    field(VAL, 0.0)
+    field(PREC, 4)
+}
+record(ao, "$(P)Control:JogSpeed4") {
+    field(DTYP, "asynFloat64")
+    field(OUT, "@asyn($(PORT),3,$(TIMEOUT=1))JOG_SPEED")
+    field(PINI, "YES")
+    field(VAL, 0.0)
+    field(PREC, 4)
+}
+record(ao, "$(P)Control:JogSpeed5") {
+    field(DTYP, "asynFloat64")
+    field(OUT, "@asyn($(PORT),4,$(TIMEOUT=1))JOG_SPEED")
+    field(PINI, "YES")
+    field(VAL, 0.0)
+    field(PREC, 4)
+}
+record(ao, "$(P)Control:JogSpeed6") {
+    field(DTYP, "asynFloat64")
+    field(OUT, "@asyn($(PORT),5,$(TIMEOUT=1))JOG_SPEED")
+    field(PINI, "YES")
+    field(VAL, 0.0)
+    field(PREC, 4)
+}
+
+
+# Jog timeout timer adapted from stdApp/Db/timer.vdb
+#
+# Automatically processes JogStop after a timeout. Calling JogStart
+# resets the timer. This is a safety feature so EPICS clients must
+# continually call JogStart within the timeout to keep jogging.
+
+record(calcout, "$(P)Control:jog_timer:count") {
+  field(DESC, "Up/Down Counter")
+  field(INPA, "$(P)Control:jog_timer:start")
+  field(INPC, "$(P)Control:jog_timer:count.VAL")
+  field(CALC, "A?C-0.1:C")
+  field(PREC, 3)
+}
+
+record(calcout, "$(P)Control:jog_timer:trigger") {
+  field(DESC, "Trigger Set")
+  field(INPA, "$(P)Control:jog_timer:stop_start NPP NMS")
+  field(CALC, "!A")
+  field(OOPT, "Transition To Non-zero")
+  field(OUT, "$(P)Control:JogStop.PROC")
+}
+
+record(calcout, "$(P)Control:jog_timer:count_reset") {
+  field(DESC, "Reset Count and Start")
+  field(INPA, "$(P)Control:jog_timer:start")
+  field(INPC, "$(P)Control:jog_timer:count")
+  field(INPD, "$(P)Control:jog_timer:reset")
+  field(CALC, "A ? D : C")
+  field(OUT, "$(P)Control:jog_timer:count.VAL NPP NMS")
+  field(FLNK, "$(P)Control:jog_timer:stop_start.VAL PP NMS")
+}
+
+record(calcout, "$(P)Control:jog_timer:stop_start") {
+  field(DESC, "Stop/Start Counter")
+  field(SCAN, "Passive")
+  field(INPA, "$(P)Control:jog_timer:count.VAL CP NMS")
+  field(INPC, "$(P)Control:jog_timer:reset NPP NMS")
+  field(INPD, "$(P)Control:jog_timer:start")
+  field(CALC, "D&A>0?9:0")
+  field(OOPT, "On Change")
+  field(OUT, "$(P)Control:jog_timer:count.SCAN NPP NMS")
+  field(FLNK, "$(P)Control:jog_timer:trigger.PROC")
+}
+
+record(calcout, "$(P)Control:jog_timer:reset") {
+  field(DESC, "Timer Reset")
+  field(SCAN, "Passive")
+  field(INPC, "$(P)Control:jog_timer:timeout CP NMS")
+  field(CALC, "C")
+}
+
+record(bo, "$(P)Control:jog_timer:set_start") {
+    field(VAL, 1)
+    field(OUT, "$(P)Control:jog_timer:start.VAL PP")
+}
+
+record(bo, "$(P)Control:jog_timer:start") {
+  field(DESC, "Start timer")
+  field(SCAN, "Passive")
+  field(DTYP, "Soft Channel")
+  field(ZNAM, "Stop")
+  field(ONAM, "Start")
+  field(FLNK, "$(P)Control:jog_timer:count_reset")
+}
+
+record(ao, "$(P)Control:jog_timer:timeout") {
+  field(SCAN, "Passive")
+  field(DTYP, "Soft Channel")
+  field(PREC, 3)
+  field(VAL, 1.0)
+}

--- a/urRobotApp/Db/rtde_control_jog.db
+++ b/urRobotApp/Db/rtde_control_jog.db
@@ -31,7 +31,7 @@ record(ao, "$(P)Control:JogSpeedX") {
     field(OUT, "@asyn($(PORT),0,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
-    field(EGU, "m/s")
+    field(EGU, "mm/s")
     field(PREC, 4)
 }
 record(ao, "$(P)Control:JogSpeedY") {
@@ -39,7 +39,7 @@ record(ao, "$(P)Control:JogSpeedY") {
     field(OUT, "@asyn($(PORT),1,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
-    field(EGU, "m/s")
+    field(EGU, "mm/s")
     field(PREC, 4)
 }
 record(ao, "$(P)Control:JogSpeedZ") {
@@ -47,7 +47,7 @@ record(ao, "$(P)Control:JogSpeedZ") {
     field(OUT, "@asyn($(PORT),2,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
-    field(EGU, "m/s")
+    field(EGU, "mm/s")
     field(PREC, 4)
 }
 record(ao, "$(P)Control:JogSpeedRoll") {
@@ -55,7 +55,7 @@ record(ao, "$(P)Control:JogSpeedRoll") {
     field(OUT, "@asyn($(PORT),3,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
-    field(EGU, "rad/s")
+    field(EGU, "deg/s")
     field(PREC, 4)
 }
 record(ao, "$(P)Control:JogSpeedPitch") {
@@ -63,7 +63,7 @@ record(ao, "$(P)Control:JogSpeedPitch") {
     field(OUT, "@asyn($(PORT),4,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
-    field(EGU, "rad/s")
+    field(EGU, "deg/s")
     field(PREC, 4)
 }
 record(ao, "$(P)Control:JogSpeedYaw") {
@@ -71,7 +71,7 @@ record(ao, "$(P)Control:JogSpeedYaw") {
     field(OUT, "@asyn($(PORT),5,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
-    field(EGU, "rad/s")
+    field(EGU, "deg/s")
     field(PREC, 4)
 }
 

--- a/urRobotApp/Db/rtde_control_jog.db
+++ b/urRobotApp/Db/rtde_control_jog.db
@@ -22,7 +22,7 @@ record(ao, "$(P)Control:JogAccel") {
     field(DTYP, "asynFloat64")
     field(PINI, "YES")
     field(EGU, "m/s/s")
-    field(VAL, 0.25)
+    field(VAL, 0.5)
     field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_ACCELERATION")
 }
 

--- a/urRobotApp/Db/rtde_control_jog.db
+++ b/urRobotApp/Db/rtde_control_jog.db
@@ -9,143 +9,144 @@ record(bi, "$(P)Control:Jogging") {
 record(bo, "$(P)Control:JogStart") {
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_START")
-    field(FLNK, "$(P)Control:jog_timer:set_start.PROC")
+    field(FLNK, "$(P)Control:jog_watchdog:set_start.PROC")
 }
 
 record(bo, "$(P)Control:JogStop") {
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_STOP")
-    field(FLNK, "$(P)Control:jog_timer:set_stop.PROC")
+    field(FLNK, "$(P)Control:jog_watchdog:set_stop.PROC")
 }
 
 record(ao, "$(P)Control:JogAccel") {
     field(DTYP, "asynFloat64")
+    field(PINI, "YES")
+    field(EGU, "m/s/s")
+    field(VAL, 0.25)
     field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_ACCELERATION")
 }
 
-record(bo, "$(P)Control:JogFeature") {
-    field(DTYP, "asynInt32")
-    field(VAL, 0)
-    field(ZNAM, "Base")
-    field(ONAM, "Tool")
-    field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_FEATURE")
-}
-
-record(ao, "$(P)Control:JogSpeed1") {
+record(ao, "$(P)Control:JogSpeedX") {
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(PORT),0,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
+    field(EGU, "m/s")
     field(PREC, 4)
 }
-record(ao, "$(P)Control:JogSpeed2") {
+record(ao, "$(P)Control:JogSpeedY") {
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(PORT),1,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
+    field(EGU, "m/s")
     field(PREC, 4)
 }
-record(ao, "$(P)Control:JogSpeed3") {
+record(ao, "$(P)Control:JogSpeedZ") {
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(PORT),2,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
+    field(EGU, "m/s")
     field(PREC, 4)
 }
-record(ao, "$(P)Control:JogSpeed4") {
+record(ao, "$(P)Control:JogSpeedRoll") {
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(PORT),3,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
+    field(EGU, "rad/s")
     field(PREC, 4)
 }
-record(ao, "$(P)Control:JogSpeed5") {
+record(ao, "$(P)Control:JogSpeedPitch") {
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(PORT),4,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
+    field(EGU, "rad/s")
     field(PREC, 4)
 }
-record(ao, "$(P)Control:JogSpeed6") {
+record(ao, "$(P)Control:JogSpeedYaw") {
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(PORT),5,$(TIMEOUT=1))JOG_SPEED")
     field(PINI, "YES")
     field(VAL, 0.0)
+    field(EGU, "rad/s")
     field(PREC, 4)
 }
 
 
-# Jog timeout timer adapted from stdApp/Db/timer.vdb
+# Jog watchdog timer adapted from stdApp/Db/timer.vdb
 #
 # Automatically processes JogStop after a timeout. Calling JogStart
 # resets the timer. This is a safety feature so EPICS clients must
-# continually call JogStart within the timeout to keep jogging.
+# continually call JogStart (kicks the watchdog) within the timeout to keep jogging.
 
-record(calcout, "$(P)Control:jog_timer:count") {
+record(calcout, "$(P)Control:jog_watchdog:count") {
   field(DESC, "Up/Down Counter")
-  field(INPA, "$(P)Control:jog_timer:start")
-  field(INPC, "$(P)Control:jog_timer:count.VAL")
+  field(INPA, "$(P)Control:jog_watchdog:start")
+  field(INPC, "$(P)Control:jog_watchdog:count.VAL")
   field(CALC, "A?C-0.1:C")
   field(PREC, 3)
 }
 
-record(calcout, "$(P)Control:jog_timer:trigger") {
+record(calcout, "$(P)Control:jog_watchdog:trigger") {
   field(DESC, "Trigger Set")
-  field(INPA, "$(P)Control:jog_timer:stop_start NPP NMS")
+  field(INPA, "$(P)Control:jog_watchdog:stop_start NPP NMS")
   field(CALC, "!A")
   field(OOPT, "Transition To Non-zero")
   field(OUT, "$(P)Control:JogStop.PROC")
 }
 
-record(calcout, "$(P)Control:jog_timer:count_reset") {
+record(calcout, "$(P)Control:jog_watchdog:count_reset") {
   field(DESC, "Reset Count and Start")
-  field(INPA, "$(P)Control:jog_timer:start")
-  field(INPC, "$(P)Control:jog_timer:count")
-  field(INPD, "$(P)Control:jog_timer:reset")
+  field(INPA, "$(P)Control:jog_watchdog:start")
+  field(INPC, "$(P)Control:jog_watchdog:count")
+  field(INPD, "$(P)Control:jog_watchdog:reset")
   field(CALC, "A ? D : C")
-  field(OUT, "$(P)Control:jog_timer:count.VAL NPP NMS")
-  field(FLNK, "$(P)Control:jog_timer:stop_start.VAL PP NMS")
+  field(OUT, "$(P)Control:jog_watchdog:count.VAL NPP NMS")
+  field(FLNK, "$(P)Control:jog_watchdog:stop_start.VAL PP NMS")
 }
 
-record(calcout, "$(P)Control:jog_timer:stop_start") {
+record(calcout, "$(P)Control:jog_watchdog:stop_start") {
   field(DESC, "Stop/Start Counter")
   field(SCAN, "Passive")
-  field(INPA, "$(P)Control:jog_timer:count.VAL CP NMS")
-  field(INPC, "$(P)Control:jog_timer:reset NPP NMS")
-  field(INPD, "$(P)Control:jog_timer:start")
+  field(INPA, "$(P)Control:jog_watchdog:count.VAL CP NMS")
+  field(INPC, "$(P)Control:jog_watchdog:reset NPP NMS")
+  field(INPD, "$(P)Control:jog_watchdog:start")
   field(CALC, "D&A>0?9:0")
   field(OOPT, "On Change")
-  field(OUT, "$(P)Control:jog_timer:count.SCAN NPP NMS")
-  field(FLNK, "$(P)Control:jog_timer:trigger.PROC")
+  field(OUT, "$(P)Control:jog_watchdog:count.SCAN NPP NMS")
+  field(FLNK, "$(P)Control:jog_watchdog:trigger.PROC")
 }
 
-record(calcout, "$(P)Control:jog_timer:reset") {
+record(calcout, "$(P)Control:jog_watchdog:reset") {
   field(DESC, "Timer Reset")
   field(SCAN, "Passive")
-  field(INPC, "$(P)Control:jog_timer:timeout CP NMS")
+  field(INPC, "$(P)Control:jog_watchdog:timeout CP NMS")
   field(CALC, "C")
 }
 
-record(bo, "$(P)Control:jog_timer:set_start") {
+record(bo, "$(P)Control:jog_watchdog:set_start") {
     field(VAL, 1)
-    field(OUT, "$(P)Control:jog_timer:start.VAL PP")
+    field(OUT, "$(P)Control:jog_watchdog:start.VAL PP")
 }
 
-record(bo, "$(P)Control:jog_timer:set_stop") {
+record(bo, "$(P)Control:jog_watchdog:set_stop") {
     field(VAL, 0)
-    field(OUT, "$(P)Control:jog_timer:start.VAL PP")
+    field(OUT, "$(P)Control:jog_watchdog:start.VAL PP")
 }
 
-record(bo, "$(P)Control:jog_timer:start") {
+record(bo, "$(P)Control:jog_watchdog:start") {
   field(DESC, "Start timer")
   field(SCAN, "Passive")
   field(DTYP, "Soft Channel")
   field(ZNAM, "Stop")
   field(ONAM, "Start")
-  field(FLNK, "$(P)Control:jog_timer:count_reset")
+  field(FLNK, "$(P)Control:jog_watchdog:count_reset")
 }
 
-record(ao, "$(P)Control:jog_timer:timeout") {
+record(ao, "$(P)Control:jog_watchdog:timeout") {
   field(SCAN, "Passive")
   field(DTYP, "Soft Channel")
   field(PREC, 3)

--- a/urRobotApp/Db/rtde_control_jog.db
+++ b/urRobotApp/Db/rtde_control_jog.db
@@ -15,6 +15,7 @@ record(bo, "$(P)Control:JogStart") {
 record(bo, "$(P)Control:JogStop") {
     field(DTYP, "asynInt32")
     field(OUT, "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))JOG_STOP")
+    field(FLNK, "$(P)Control:jog_timer:set_stop.PROC")
 }
 
 record(ao, "$(P)Control:JogAccel") {
@@ -127,6 +128,11 @@ record(calcout, "$(P)Control:jog_timer:reset") {
 
 record(bo, "$(P)Control:jog_timer:set_start") {
     field(VAL, 1)
+    field(OUT, "$(P)Control:jog_timer:start.VAL PP")
+}
+
+record(bo, "$(P)Control:jog_timer:set_stop") {
+    field(VAL, 0)
     field(OUT, "$(P)Control:jog_timer:start.VAL PP")
 }
 

--- a/urRobotApp/src/rtde_control_driver.cpp
+++ b/urRobotApp/src/rtde_control_driver.cpp
@@ -190,6 +190,12 @@ RTDEControl::RTDEControl(const char* asyn_port_name, const char* dash_drv_name, 
     createParam("CUSTOM_SCRIPT_RUNNING", asynParamInt32, &customScriptRunningIndex_);
     createParam("CUSTOM_SCRIPT_ERROR", asynParamInt32, &customScriptErrorIndex_);
     createParam("CUSTOM_SCRIPT_TIMEOUT", asynParamFloat64, &customScriptTimeoutIndex_);
+    createParam("JOG_START", asynParamInt32, &jogStartIndex_);
+    createParam("JOG_STOP", asynParamInt32, &jogStopIndex_);
+    createParam("JOG_SPEED", asynParamFloat64, &jogSpeedIndex_);
+    createParam("JOG_FEATURE", asynParamInt32, &jogFeatureIndex_);
+    createParam("JOG_ACCELERATION", asynParamFloat64, &jogAccelerationIndex_);
+    createParam("JOGGING", asynParamInt32, &joggingIndex_);
 
     // gets log level from SPDLOG_LEVEL environment variable
     spdlog::cfg::load_env_levels();
@@ -366,6 +372,13 @@ asynStatus RTDEControl::writeFloat64(asynUser* pasynUser, epicsFloat64 value) {
         spdlog::debug("Setting linear blend to {:.4f}", linear_blend_);
     }
 
+    else if (function == jogSpeedIndex_) {
+        // convert commanded x,y,z to meters and roll, pitch, yaw to radians
+        const double val = (addr >= 3) ? (value * M_PI / 180.0) : (value / 1000.0);
+        jog_speeds_[addr] = val;
+        new_jog_ = true;
+    }
+
     else {
         asynPortDriver::writeFloat64(pasynUser, value);
     }
@@ -520,6 +533,45 @@ asynStatus RTDEControl::writeInt32(asynUser* pasynUser, epicsInt32 value) {
         drv_receive_->lock();
         drv_receive_->getIntegerParam(outputIntRegId_, &custom_script_running_count_);
         drv_receive_->unlock();
+    }
+
+    else if (function == jogFeatureIndex_) {
+        new_jog_ = true;
+        if (value == 0) {
+            jog_feature_ = ur_rtde::RTDEControlInterface::FEATURE_BASE;
+        } else if (value == 1) {
+            jog_feature_ = ur_rtde::RTDEControlInterface::FEATURE_TOOL;
+        }
+    }
+
+    else if (function == jogStartIndex_) {
+        if (new_jog_) {
+            double accel = 0.0;
+            getDoubleParam(jogAccelerationIndex_, &accel);
+            // TODO: rtde_control_->jogStart(...);
+            spdlog::debug("Starting jog: feature={}; accel={}, speeds=[{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f}]",
+                          jog_feature_,
+                          accel,
+                          jog_speeds_[0],
+                          jog_speeds_[1],
+                          jog_speeds_[2],
+                          jog_speeds_[3],
+                          jog_speeds_[4],
+                          jog_speeds_[5]
+                          );
+            new_jog_ = false;
+        }
+        setIntegerParam(joggingIndex_, 1);
+    }
+
+    else if (function == jogStopIndex_) {
+        // TODO: rtde_control_->jogStop();
+        spdlog::debug("Stopping jog");
+        setIntegerParam(joggingIndex_, 0);
+    }
+
+    else {
+        asynPortDriver::writeInt32(pasynUser, value);
     }
 
 skip:

--- a/urRobotApp/src/rtde_control_driver.cpp
+++ b/urRobotApp/src/rtde_control_driver.cpp
@@ -379,6 +379,11 @@ asynStatus RTDEControl::writeFloat64(asynUser* pasynUser, epicsFloat64 value) {
         new_jog_ = true;
     }
 
+    else if (function == jogAccelerationIndex_) {
+        new_jog_ = true;
+        asynPortDriver::writeFloat64(pasynUser, value);
+    }
+
     else {
         asynPortDriver::writeFloat64(pasynUser, value);
     }
@@ -537,6 +542,8 @@ asynStatus RTDEControl::writeInt32(asynUser* pasynUser, epicsInt32 value) {
 
     else if (function == jogFeatureIndex_) {
         new_jog_ = true;
+        // probably could just call the base class method and use value
+        // directory instead of ur_rtde::RTDEControlInterface::Feature enum
         if (value == 0) {
             jog_feature_ = ur_rtde::RTDEControlInterface::FEATURE_BASE;
         } else if (value == 1) {

--- a/urRobotApp/src/rtde_control_driver.cpp
+++ b/urRobotApp/src/rtde_control_driver.cpp
@@ -556,7 +556,7 @@ asynStatus RTDEControl::writeInt32(asynUser* pasynUser, epicsInt32 value) {
         if (new_jog_) {
             double accel = 0.0;
             getDoubleParam(jogAccelerationIndex_, &accel);
-            // TODO: rtde_control_->jogStart(...);
+            rtde_control_->speedL(jog_speeds_, 0.25, 0.5);
             spdlog::debug("Starting jog: feature={}; accel={}, speeds=[{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f}]",
                           jog_feature_,
                           accel,
@@ -573,8 +573,8 @@ asynStatus RTDEControl::writeInt32(asynUser* pasynUser, epicsInt32 value) {
     }
 
     else if (function == jogStopIndex_) {
-        // TODO: rtde_control_->jogStop();
         spdlog::debug("Stopping jog");
+        rtde_control_->speedStop();
         setIntegerParam(joggingIndex_, 0);
     }
 

--- a/urRobotApp/src/rtde_control_driver.cpp
+++ b/urRobotApp/src/rtde_control_driver.cpp
@@ -375,6 +375,7 @@ asynStatus RTDEControl::writeFloat64(asynUser* pasynUser, epicsFloat64 value) {
     else if (function == jogSpeedIndex_) {
         // convert commanded x,y,z to meters and roll, pitch, yaw to radians
         const double val = (addr >= 3) ? (value * M_PI / 180.0) : (value / 1000.0);
+        spdlog::debug("Setting jog speed[{}] to {:.4f}", addr, val);
         jog_speeds_[addr] = val;
         new_jog_ = true;
     }

--- a/urRobotApp/src/rtde_control_driver.cpp
+++ b/urRobotApp/src/rtde_control_driver.cpp
@@ -193,7 +193,6 @@ RTDEControl::RTDEControl(const char* asyn_port_name, const char* dash_drv_name, 
     createParam("JOG_START", asynParamInt32, &jogStartIndex_);
     createParam("JOG_STOP", asynParamInt32, &jogStopIndex_);
     createParam("JOG_SPEED", asynParamFloat64, &jogSpeedIndex_);
-    createParam("JOG_FEATURE", asynParamInt32, &jogFeatureIndex_);
     createParam("JOG_ACCELERATION", asynParamFloat64, &jogAccelerationIndex_);
     createParam("JOGGING", asynParamInt32, &joggingIndex_);
 
@@ -541,32 +540,14 @@ asynStatus RTDEControl::writeInt32(asynUser* pasynUser, epicsInt32 value) {
         drv_receive_->unlock();
     }
 
-    else if (function == jogFeatureIndex_) {
-        new_jog_ = true;
-        // probably could just call the base class method and use value
-        // directory instead of ur_rtde::RTDEControlInterface::Feature enum
-        if (value == 0) {
-            jog_feature_ = ur_rtde::RTDEControlInterface::FEATURE_BASE;
-        } else if (value == 1) {
-            jog_feature_ = ur_rtde::RTDEControlInterface::FEATURE_TOOL;
-        }
-    }
-
     else if (function == jogStartIndex_) {
         if (new_jog_) {
             double accel = 0.0;
             getDoubleParam(jogAccelerationIndex_, &accel);
-            rtde_control_->speedL(jog_speeds_, 0.25, 0.5);
-            spdlog::debug("Starting jog: feature={}; accel={}, speeds=[{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f}]",
-                          jog_feature_,
-                          accel,
-                          jog_speeds_[0],
-                          jog_speeds_[1],
-                          jog_speeds_[2],
-                          jog_speeds_[3],
-                          jog_speeds_[4],
-                          jog_speeds_[5]
-                          );
+            rtde_control_->speedL(jog_speeds_, accel, 0.01);
+            spdlog::debug("Starting jog: accel={}, speeds=[{:.2f},{:.2f},{:.2f},{:.2f},{:.2f},{:.2f}]", accel,
+                          jog_speeds_[0], jog_speeds_[1], jog_speeds_[2], jog_speeds_[3], jog_speeds_[4],
+                          jog_speeds_[5]);
             new_jog_ = false;
         }
         setIntegerParam(joggingIndex_, 1);

--- a/urRobotApp/src/rtde_control_driver.hpp
+++ b/urRobotApp/src/rtde_control_driver.hpp
@@ -60,6 +60,11 @@ class RTDEControl : public asynPortDriver {
     /// TCP pose offset: x,y,z (meters), roll,pitch,yaw (radians)
     std::vector<double> tcp_offset_ = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
+    /// Jog speed vector: Translation speed (m/s), rotational speed (rad/s)
+    std::vector<double> jog_speeds_ = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    int jog_feature_ = ur_rtde::RTDEControlInterface::FEATURE_BASE;
+    bool new_jog_ = false;
+
     /// Dynamics for moveJ (all in rad/s, rad/s^2, meters)
     double joint_speed_ = 0.5;
     double joint_accel_ = 1.4;
@@ -139,15 +144,25 @@ class RTDEControl : public asynPortDriver {
     int runWaypointActionIndex_;  ///< toggled to trigger waypoint action processing
     int waypointActionDoneIndex_; ///< set to 1 by action chain when action completes
 
-    /// Script / safety
-    int reuploadCtrlScriptIndex_;
-    int stopCtrlScriptIndex_;
-    int teachModeIndex_;
-    int triggerProtStopIndex_;
+    /// URScript
     int customScriptFileIndex_;
     int customInlineScriptIndex_;
     int runCustomScriptFileIndex_;
     int customScriptRunningIndex_;
     int customScriptErrorIndex_;
     int customScriptTimeoutIndex_;
+
+    /// Jogging
+    int jogStartIndex_;
+    int jogStopIndex_;
+    int jogSpeedIndex_; ///< Vector of jog speeds, addr 0-5
+    int jogFeatureIndex_;
+    int jogAccelerationIndex_;
+    int joggingIndex_;
+
+    /// Misc
+    int reuploadCtrlScriptIndex_;
+    int stopCtrlScriptIndex_;
+    int teachModeIndex_;
+    int triggerProtStopIndex_;
 };

--- a/urRobotApp/src/rtde_control_driver.hpp
+++ b/urRobotApp/src/rtde_control_driver.hpp
@@ -62,7 +62,6 @@ class RTDEControl : public asynPortDriver {
 
     /// Jog speed vector: Translation speed (m/s), rotational speed (rad/s)
     std::vector<double> jog_speeds_ = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-    int jog_feature_ = ur_rtde::RTDEControlInterface::FEATURE_BASE;
     bool new_jog_ = false;
 
     /// Dynamics for moveJ (all in rad/s, rad/s^2, meters)
@@ -156,7 +155,6 @@ class RTDEControl : public asynPortDriver {
     int jogStartIndex_;
     int jogStopIndex_;
     int jogSpeedIndex_; ///< Vector of jog speeds, addr 0-5
-    int jogFeatureIndex_;
     int jogAccelerationIndex_;
     int joggingIndex_;
 


### PR DESCRIPTION
Adds continuous velocity-based jogging in Cartesian space using the ur_rtde speedL/speedStop API. Unlike moveJ/moveL which move to a target and stop, jogging moves the robot at a specified speed until explicitly stopped, making it suitable for joystick or gamepad control.
## Changes
Driver (rtde_control_driver.cpp/.hpp):
- New asyn parameters: JOG_START, JOG_STOP, JOG_SPEED (addr 0-5), JOG_ACCELERATION, JOGGING
- JogStart calls rtde_control_->speedL() with the current speed vector and acceleration
- JogStop calls rtde_control_->speedStop()
- Speed PVs are converted from user units (mm/s, deg/s) to internal units (m/s, rad/s)
- A new_jog_ flag ensures speedL is only called when parameters have changed
## Database (rtde_control_jog.db):
- User-facing records: JogStart, JogStop, JogAccel, JogSpeedX/Y/Z/Roll/Pitch/Yaw, Jogging
- Watchdog safety timer (adapted from stdApp/Db/timer.vdb) that automatically triggers JogStop if JogStart is not re-processed within 1 second
## Documentation:
- New "Jogging (Advanced)" section in usage.md
- New rtde_control_jog.db section in pv_reference_guide.md
Notes
- This is an advanced feature. The client must repeatedly process JogStart to keep the watchdog alive. The jog database is intentionally not loaded by urRobot.iocsh and must be loaded manually.
- Uses speedL/speedStop rather than the ur_rtde jogStart/jogStop API due to upstream bugs in the jog implementation (see sdurobotics/ur_rtde#292 (https://gitlab.com/sdurobotics/ur_rtde/-/issues/292), sdurobotics/ur_rtde#238 (https://gitlab.com/sdurobotics/ur_rtde/-/issues/238), and a missing fast-path for JOG_START in sendCommand).
- Motion is in the robot base frame only.

*Documenation assisted by Claude Opus 4.6*