### PR TITLE
urRobot EPICS support module integration

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -1,49 +1,41 @@
 # CONFIG_SITE
 
+-include $(SUPPORT)/configure/CONFIG_SITE
+
 # Make any application-specific changes to the EPICS build
-# configuration variables in this file.
+#   configuration variables in this file.
 #
 # Host/target specific settings can be specified in files named
-#  CONFIG_SITE.$(EPICS_HOST_ARCH).Common
-#  CONFIG_SITE.Common.$(T_A)
-#  CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 
 # CHECK_RELEASE controls the consistency checking of the support
 #   applications pointed to by the RELEASE* files.
 # Normally CHECK_RELEASE should be set to YES.
 # Set CHECK_RELEASE to NO to disable checking completely.
 # Set CHECK_RELEASE to WARN to perform consistency checking but
-#   continue building anyway if conflicts are found.
+#   continue building even if conflicts are found.
 CHECK_RELEASE = YES
 
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS = 
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.
-#INSTALL_LOCATION=</path/name/to/install/top>
+#INSTALL_LOCATION=</absolute/path/to/install/top>
 
-# To build the IOC application set BUILD_IOCS to YES
-# Otherwise set it to NO
-BUILD_IOCS=NO
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
 
-# Set this when your IOC and the host use different paths
-#   to access the application. This will be needed to boot
-#   from a Microsoft FTP server or with some NFS mounts.
-# You must rebuild in the iocBoot directory for this to
-#   take effect.
-#IOCS_APPL_TOP = </IOC/path/to/application/top>
+WITH_BOOST = YES
 
-TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
-
-# These allow developers to override the CONFIG_SITE variable
-# settings without having to modify the configure/CONFIG_SITE
-# file itself.
--include $(TOP)/../CONFIG_SITE.local
--include $(TOP)/../configure/CONFIG_SITE.local
--include $(TOP)/configure/CONFIG_SITE.local
--include $(TOP)/configure/CONFIG_SITE.local.$(OS_CLASS)
-
-
+BOOST_PACKAGE_NAME=boost
+BOOST_VERSION=1.64.0
+BOOST_TOP=$(PSPKG_ROOT)/release/$(BOOST_PACKAGE_NAME)/$(BOOST_VERSION)
+BOOST_LIB=$(BOOST_TOP)/$(EPICS_HOST_ARCH)/lib
+BOOST_INCLUDE=$(BOOST_TOP)/$(EPICS_HOST_ARCH)/include

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -39,7 +39,9 @@ WITH_BOOST = YES
 PSPKG_ROOT ?= /cds/group/pcds/pkg_mgr
 
 BOOST_PACKAGE_NAME=boost
-BOOST_VERSION=1.64.0
+BOOST_VERSION=1.91.0
 BOOST_TOP=$(PSPKG_ROOT)/release/$(BOOST_PACKAGE_NAME)/$(BOOST_VERSION)
 BOOST_LIB=$(BOOST_TOP)/$(EPICS_HOST_ARCH)/lib
+# Point at the dir that CONTAINS boost/ (so <boost/variant.hpp> resolves).
+# Do NOT append /boost here.
 BOOST_INCLUDE=$(BOOST_TOP)/$(EPICS_HOST_ARCH)/include

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -39,7 +39,7 @@ WITH_BOOST = YES
 PSPKG_ROOT ?= /cds/group/pcds/pkg_mgr
 
 BOOST_PACKAGE_NAME=boost
-BOOST_VERSION=1.91.0
+BOOST_VERSION=1.77.0
 BOOST_TOP=$(PSPKG_ROOT)/release/$(BOOST_PACKAGE_NAME)/$(BOOST_VERSION)
 BOOST_LIB=$(BOOST_TOP)/$(EPICS_HOST_ARCH)/lib
 # Point at the dir that CONTAINS boost/ (so <boost/variant.hpp> resolves).

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -34,6 +34,10 @@ CHECK_RELEASE = YES
 
 WITH_BOOST = YES
 
+# PSPKG_ROOT is normally exported by the PCDS build environment. Provide a
+# fallback so the Boost paths still resolve if it is not set in the environment.
+PSPKG_ROOT ?= /cds/group/pcds/pkg_mgr
+
 BOOST_PACKAGE_NAME=boost
 BOOST_VERSION=1.64.0
 BOOST_TOP=$(PSPKG_ROOT)/release/$(BOOST_PACKAGE_NAME)/$(BOOST_VERSION)

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,16 +1,21 @@
-# RELEASE Location of external products
+#RELEASE Location of external products
 # Run "gnumake clean uninstall install" in the application
 # top directory each time this file is changed.
-
-##############################################################################
-
-# SUPPORT =
-# EPICS_BASE =
-# ASYN =
-
-# These lines allow developers to override these RELEASE settings
-# without having to modify this file directly.
--include $(TOP)/../RELEASE.local
--include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
 -include $(TOP)/configure/RELEASE.local
 
+TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
+
+# EPICS_BASE usually appears last so other apps can override stuff:
+#EPICS_BASE=/home/oxygen/MOONEY/epics/bazaar/base-3.14
+#-include $(TOP)/../configure/EPICS_BASE.$(EPICS_HOST_ARCH)
+
+#Capfast users may need the following definitions
+#CAPFAST_TEMPLATES=
+#SCH2EDIF_PATH=
+
+# Check for valid macro definitions for module release directories
+# You can add tests here to make sure RELEASE.local defined valid
+# macros for all the module dependencies
+ifeq ($(wildcard $(EPICS_BASE)/include),)
+$(error Invalid EPICS_BASE: $(EPICS_BASE))
+endif

--- a/urRobotApp/src/Makefile
+++ b/urRobotApp/src/Makefile
@@ -31,38 +31,41 @@ urRobot_LIBS += asyn
 urRobot_LIBS += rtde
 urRobot_LIBS += $(EPICS_BASE_IOC_LIBS)
 
+# Boost wiring (see WITH_BOOST / BOOST_* in configure/CONFIG_SITE).
+# When BOOST_LIB is set (e.g. a PSPKG package), link Boost from there via the
+# *_DIR mechanism; otherwise fall back to the system Boost libraries. The
+# resulting names are applied to the urRobot library and to each PROD below.
 ifeq ($(WITH_BOOST),YES)
-  ifeq ($(BOOST_EXTERNAL),NO)
-    PROD_SYS_LIBS += boost_system
-  else
+  USR_INCLUDES += -I$(BOOST_INCLUDE)
+  ifneq ($(BOOST_EXTERNAL),NO)
     ifdef BOOST_LIB
       boost_system_DIR = $(BOOST_LIB)
-      PROD_LIBS     += boost_system
-          boost_system_DIR = $(BOOST_LIB)
-    else
-      PROD_SYS_LIBS += boost_system
+      boost_thread_DIR = $(BOOST_LIB)
+      BOOST_TGT_LIBS = boost_system boost_thread
     endif
+  endif
+  ifndef BOOST_TGT_LIBS
+    BOOST_TGT_SYS_LIBS = boost_system boost_thread
   endif
 endif
 
-
-#urRobot_SYS_LIBS += boost_system
-#urRobot_SYS_LIBS += boost_thread
+urRobot_LIBS     += $(BOOST_TGT_LIBS)
+urRobot_SYS_LIBS += $(BOOST_TGT_SYS_LIBS)
 
 # Tool for calibrating the Robotiq Gripper
 PROD += calibrate_gripper
 calibrate_gripper_SRCS += calibrate_gripper.cpp
 calibrate_gripper_LIBS += rtde
-#calibrate_gripper_SYS_LIBS += boost_system
-#calibrate_gripper_SYS_LIBS += boost_thread
+calibrate_gripper_LIBS += $(BOOST_TGT_LIBS)
+calibrate_gripper_SYS_LIBS += $(BOOST_TGT_SYS_LIBS)
 calibrate_gripper_SYS_LIBS += pthread
 
 # Program for testing ur_rtde by itself without asyn
 TESTPROD += urtest
 urtest_SRCS += urtest.cpp
 urtest_LIBS += rtde
-#urtest_SYS_LIBS += boost_system
-#urtest_SYS_LIBS += boost_thread
+urtest_LIBS += $(BOOST_TGT_LIBS)
+urtest_SYS_LIBS += $(BOOST_TGT_SYS_LIBS)
 urtest_SYS_LIBS += pthread
 
 endif

--- a/urRobotApp/src/Makefile
+++ b/urRobotApp/src/Makefile
@@ -30,23 +30,39 @@ urRobot_SRCS += gripper_driver.cpp
 urRobot_LIBS += asyn
 urRobot_LIBS += rtde
 urRobot_LIBS += $(EPICS_BASE_IOC_LIBS)
-urRobot_SYS_LIBS += boost_system
-urRobot_SYS_LIBS += boost_thread
+
+ifeq ($(WITH_BOOST),YES)
+  ifeq ($(BOOST_EXTERNAL),NO)
+    PROD_SYS_LIBS += boost_system
+  else
+    ifdef BOOST_LIB
+      boost_system_DIR = $(BOOST_LIB)
+      PROD_LIBS     += boost_system
+          boost_system_DIR = $(BOOST_LIB)
+    else
+      PROD_SYS_LIBS += boost_system
+    endif
+  endif
+endif
+
+
+#urRobot_SYS_LIBS += boost_system
+#urRobot_SYS_LIBS += boost_thread
 
 # Tool for calibrating the Robotiq Gripper
 PROD += calibrate_gripper
 calibrate_gripper_SRCS += calibrate_gripper.cpp
 calibrate_gripper_LIBS += rtde
-calibrate_gripper_SYS_LIBS += boost_system
-calibrate_gripper_SYS_LIBS += boost_thread
+#calibrate_gripper_SYS_LIBS += boost_system
+#calibrate_gripper_SYS_LIBS += boost_thread
 calibrate_gripper_SYS_LIBS += pthread
 
 # Program for testing ur_rtde by itself without asyn
 TESTPROD += urtest
 urtest_SRCS += urtest.cpp
 urtest_LIBS += rtde
-urtest_SYS_LIBS += boost_system
-urtest_SYS_LIBS += boost_thread
+#urtest_SYS_LIBS += boost_system
+#urtest_SYS_LIBS += boost_thread
 urtest_SYS_LIBS += pthread
 
 endif

--- a/urRobotSupport/rtdeSrc/Makefile
+++ b/urRobotSupport/rtdeSrc/Makefile
@@ -70,7 +70,6 @@ INC += ur_rtde/rtde_receive_interface.h
 INC += ur_rtde/rtde_receive_interface_doc.h
 INC += ur_rtde/rtde_utility.h
 INC += ur_rtde/script_client.h
-INC += ur_rtde/thread_utility.h
 INC += urcl/default_log_handler.h
 INC += urcl/log.h
 INC += urcl/script_sender.h

--- a/urRobotSupport/rtdeSrc/Makefile
+++ b/urRobotSupport/rtdeSrc/Makefile
@@ -70,6 +70,7 @@ INC += ur_rtde/rtde_receive_interface.h
 INC += ur_rtde/rtde_receive_interface_doc.h
 INC += ur_rtde/rtde_utility.h
 INC += ur_rtde/script_client.h
+INC += ur_rtde/thread_utility.h
 INC += urcl/default_log_handler.h
 INC += urcl/log.h
 INC += urcl/script_sender.h

--- a/urRobotSupport/rtdeSrc/Makefile
+++ b/urRobotSupport/rtdeSrc/Makefile
@@ -9,6 +9,11 @@ SRC_DIRS += ../generated
 USR_INCLUDES += -I../ur_rtde/include
 USR_INCLUDES += -I../generated
 
+# Boost headers (see WITH_BOOST / BOOST_* in configure/CONFIG_SITE)
+ifeq ($(WITH_BOOST),YES)
+USR_INCLUDES += -I$(BOOST_INCLUDE)
+endif
+
 USR_CXXFLAGS += -std=c++11
 
 LIBRARY = rtde
@@ -32,8 +37,23 @@ rtde_SRCS_Darwin += tcp_server.cpp
 rtde_SRCS_Darwin += log.cpp
 rtde_SRCS_Darwin += default_log_handler.cpp
 
-rtde_SYS_LIBS += boost_system
-rtde_SYS_LIBS += boost_thread
+# Boost libraries: link from BOOST_LIB when set (PSPKG package), else system
+ifeq ($(WITH_BOOST),YES)
+  ifneq ($(BOOST_EXTERNAL),NO)
+    ifdef BOOST_LIB
+      boost_system_DIR = $(BOOST_LIB)
+      boost_thread_DIR = $(BOOST_LIB)
+      rtde_LIBS += boost_system
+      rtde_LIBS += boost_thread
+    else
+      rtde_SYS_LIBS += boost_system
+      rtde_SYS_LIBS += boost_thread
+    endif
+  else
+    rtde_SYS_LIBS += boost_system
+    rtde_SYS_LIBS += boost_thread
+  endif
+endif
 
 INC += ur_rtde/dashboard_client.h
 INC += ur_rtde/dashboard_enums.h


### PR DESCRIPTION
## Summary

Integrate the `urRobot` EPICS support module for Universal Robots e-series robot arms into the SLAC-EPICS environment, and get it building on Rocky 9. The build wires in Boost via the a pkg_mgr package version. 

## What's included

- `configure/CONFIG_SITE`: Set `WITH_BOOST` and locate the Boost 1.77.0 package under `PSPKG_ROOT`, with a fallback when `PSPKG_ROOT` is not exported.
- `urRobotApp/src/Makefile` : Add the Boost include path and link `boost_system` and `boost_thread` into the `urRobot` library and the `calibrate_gripper` and `urtest` PRODs, via the `*_DIR` mechanism when `BOOST_LIB` points at a package.
- `urRobotSupport/rtdeSrc/Makefile` : Add the same include path and Boost linkage to the vendored `rtde` library.

## Motivation

Bring up the `urRobot` EPICS support module for Universal Robots e-series robot arms in the SLAC-EPICS environment. The module wraps the `ur_rtde` library, which depends on Boost, so building it on Rocky 9 first requires resolving Boost.

The module built on RHEL 7 (Boost 1.64/1.69) but failed on Rocky 9. Two separate Boost incompatibilities surfaced once a build path was wired up:

1. **`boost::asio::io_service` was removed.** Deprecated in Boost 1.66, removed in 1.87. The pinned `ur_rtde` (`cb521a5`) still uses `io_service`, so it will not compile against a current Boost.
2. **`libboost_system` no longer ships.** `boost_system` became header-only in 1.69 and the compiled stub was dropped around 1.87. The link line references `boost_system`, so linking fails when the library is absent.

Both bit the first attempt against the Rocky 9 Boost 1.91 package. Building Boost 1.75 from source via `pkg_mgr` also failed (`b2` could not build it cleanly with GCC 11.5 and the `python3.11` variant). Boost **1.77.0** resolves it: it exists as a package and predates both removals, so it still provides the `io_service` headers and `libboost_system` the original code needs. This keeps `ur_rtde` at the tested upstream pin with no source bump.

## Limitations

- Pinned to **Boost 1.77.0**. Newer Boost (>= 1.87) will not work without porting `ur_rtde` to `io_context` and dropping the `boost_system` link.
- Validated on `rhel9-x86_64` only. Other architectures are untested.
- The Boost path assumes the PCDS package layout (`release/boost/1.77.0` -> `1.77.0-python3.11`, resolved through `$(EPICS_HOST_ARCH)`). A different layout needs `BOOST_*` overridden in `CONFIG_SITE.local`.

## Prerequisites

- Rocky 9 build host with GCC 11.5.
- PCDS Boost 1.77.0 package available at `$(PSPKG_ROOT)/release/boost/1.77.0/$(EPICS_HOST_ARCH)/{include,lib}`.
- `PSPKG_ROOT` exported by the build environment (falls back to `/cds/group/pcds/pkg_mgr`).
- Submodules initialized: `git submodule update --init` (pins `ur_rtde` at `cb521a5`).

## Follow-ups

- Migrate `ur_rtde` to `io_context` and drop the `boost_system` link so the module can build against modern Boost (>= 1.87). Upstream commit `64ed449` does this.