### PR TITLE
Rm automove

### DIFF
--- a/docs/pv_reference_guide.md
+++ b/docs/pv_reference_guide.md
@@ -157,61 +157,71 @@ robot controller, `caput Dashboard:Play 1` and `caput Dashboard:Play.PROC 1` (an
 | Control:JointAcceleration    | ao     | Acceleration for moveJ (deg/s/s)     |
 | Control:JointBlend    | ao     | Blend radius for moveJ (mm)     |
 | Control:stopJ    | bo     | Stops an in-progress asynchronous moveJ     |
-| Control:AutoMoveJ    | bo     | If 1, moveJ runs automatically when any JxCmd changes     |
-| Control:J1Cmd    | ao     | Commanded angle for joint 1 (deg)     |
+| Control:J1Cmd    | ao     | Commanded angle for joint 1 (deg). Does not trigger motion.     |
+| Control:J1CmdU    | ao     | Sets J1 target and executes moveJ     |
 | Control:J1TweakVal    | ao     | Joint 1 tweak step size     |
-| Control:J1TweakFwd    | bo     | Tweak joint 1 forward by J1TweakVal     |
-| Control:J1TweakRev    | bo     | Tweak joint 1 backward by J1TweakVal     |
-| Control:J2Cmd    | ao     | Commanded angle for joint 2 (deg)     |
+| Control:J1TweakFwd    | calcout     | Tweak joint 1 forward by J1TweakVal (writes to J1CmdU)     |
+| Control:J1TweakRev    | calcout     | Tweak joint 1 backward by J1TweakVal (writes to J1CmdU)     |
+| Control:J2Cmd    | ao     | Commanded angle for joint 2 (deg). Does not trigger motion.     |
+| Control:J2CmdU    | ao     | Sets J2 target and executes moveJ     |
 | Control:J2TweakVal    | ao     | Joint 2 tweak step size     |
-| Control:J2TweakFwd    | bo     | Tweak joint 2 forward by J2TweakVal     |
-| Control:J2TweakRev    | bo     | Tweak joint 2 backward by J2TweakVal     |
-| Control:J3Cmd    | ao     | Commanded angle for joint 3 (deg)     |
+| Control:J2TweakFwd    | calcout     | Tweak joint 2 forward by J2TweakVal (writes to J2CmdU)     |
+| Control:J2TweakRev    | calcout     | Tweak joint 2 backward by J2TweakVal (writes to J2CmdU)     |
+| Control:J3Cmd    | ao     | Commanded angle for joint 3 (deg). Does not trigger motion.     |
+| Control:J3CmdU    | ao     | Sets J3 target and executes moveJ     |
 | Control:J3TweakVal    | ao     | Joint 3 tweak step size     |
-| Control:J3TweakFwd    | bo     | Tweak joint 3 forward by J3TweakVal     |
-| Control:J3TweakRev    | bo     | Tweak joint 3 backward by J3TweakVal     |
-| Control:J4Cmd    | ao     | Commanded angle for joint 4 (deg)     |
+| Control:J3TweakFwd    | calcout     | Tweak joint 3 forward by J3TweakVal (writes to J3CmdU)     |
+| Control:J3TweakRev    | calcout     | Tweak joint 3 backward by J3TweakVal (writes to J3CmdU)     |
+| Control:J4Cmd    | ao     | Commanded angle for joint 4 (deg). Does not trigger motion.     |
+| Control:J4CmdU    | ao     | Sets J4 target and executes moveJ     |
 | Control:J4TweakVal    | ao     | Joint 4 tweak step size     |
-| Control:J4TweakFwd    | bo     | Tweak joint 4 forward by J4TweakVal     |
-| Control:J4TweakRev    | bo     | Tweak joint 4 backward by J4TweakVal     |
-| Control:J5Cmd    | ao     | Commanded angle for joint 5 (deg)     |
+| Control:J4TweakFwd    | calcout     | Tweak joint 4 forward by J4TweakVal (writes to J4CmdU)     |
+| Control:J4TweakRev    | calcout     | Tweak joint 4 backward by J4TweakVal (writes to J4CmdU)     |
+| Control:J5Cmd    | ao     | Commanded angle for joint 5 (deg). Does not trigger motion.     |
+| Control:J5CmdU    | ao     | Sets J5 target and executes moveJ     |
 | Control:J5TweakVal    | ao     | Joint 5 tweak step size     |
-| Control:J5TweakFwd    | bo     | Tweak joint 5 forward by J5TweakVal     |
-| Control:J5TweakRev    | bo     | Tweak joint 5 backward by J5TweakVal     |
-| Control:J6Cmd    | ao     | Commanded angle for joint 6 (deg)     |
+| Control:J5TweakFwd    | calcout     | Tweak joint 5 forward by J5TweakVal (writes to J5CmdU)     |
+| Control:J5TweakRev    | calcout     | Tweak joint 5 backward by J5TweakVal (writes to J5CmdU)     |
+| Control:J6Cmd    | ao     | Commanded angle for joint 6 (deg). Does not trigger motion.     |
+| Control:J6CmdU    | ao     | Sets J6 target and executes moveJ     |
 | Control:J6TweakVal    | ao     | Joint 6 tweak step size     |
-| Control:J6TweakFwd    | bo     | Tweak joint 6 forward by J6TweakVal     |
-| Control:J6TweakRev    | bo     | Tweak joint 6 backward by J6TweakVal     |
+| Control:J6TweakFwd    | calcout     | Tweak joint 6 forward by J6TweakVal (writes to J6CmdU)     |
+| Control:J6TweakRev    | calcout     | Tweak joint 6 backward by J6TweakVal (writes to J6CmdU)     |
 | Control:moveL    | bo     | Executes moveL to the commanded TCP pose     |
 | Control:LinearSpeed    | ao     | Speed for moveL (mm/s)     |
 | Control:LinearAcceleration    | ao     | Acceleration for moveL (mm/s/s)     |
 | Control:LinearBlend    | ao     | Blend radius for moveL (mm)     |
 | Control:stopL    | bo     | Stops an in-progress asynchronous moveL     |
-| Control:AutoMoveL    | bo     | If 1, moveL runs automatically when any PoseCmd changes     |
-| Control:PoseXCmd    | ao     | Commanded TCP X (mm)     |
+| Control:PoseXCmd    | ao     | Commanded TCP X (mm). Does not trigger motion.     |
+| Control:PoseXCmdU    | ao     | Sets X target and executes moveL     |
 | Control:PoseXTweakVal    | ao     | X tweak step size     |
-| Control:PoseXTweakFwd    | bo     | Tweak TCP X forward     |
-| Control:PoseXTweakRev    | bo     | Tweak TCP X backward     |
-| Control:PoseYCmd    | ao     | Commanded TCP Y (mm)     |
+| Control:PoseXTweakFwd    | calcout     | Tweak TCP X forward (writes to PoseXCmdU)     |
+| Control:PoseXTweakRev    | calcout     | Tweak TCP X backward (writes to PoseXCmdU)     |
+| Control:PoseYCmd    | ao     | Commanded TCP Y (mm). Does not trigger motion.     |
+| Control:PoseYCmdU    | ao     | Sets Y target and executes moveL     |
 | Control:PoseYTweakVal    | ao     | Y tweak step size     |
-| Control:PoseYTweakFwd    | bo     | Tweak TCP Y forward     |
-| Control:PoseYTweakRev    | bo     | Tweak TCP Y backward     |
-| Control:PoseZCmd    | ao     | Commanded TCP Z (mm)     |
+| Control:PoseYTweakFwd    | calcout     | Tweak TCP Y forward (writes to PoseYCmdU)     |
+| Control:PoseYTweakRev    | calcout     | Tweak TCP Y backward (writes to PoseYCmdU)     |
+| Control:PoseZCmd    | ao     | Commanded TCP Z (mm). Does not trigger motion.     |
+| Control:PoseZCmdU    | ao     | Sets Z target and executes moveL     |
 | Control:PoseZTweakVal    | ao     | Z tweak step size     |
-| Control:PoseZTweakFwd    | bo     | Tweak TCP Z forward     |
-| Control:PoseZTweakRev    | bo     | Tweak TCP Z backward     |
-| Control:PoseRollCmd    | ao     | Commanded TCP roll (deg)     |
+| Control:PoseZTweakFwd    | calcout     | Tweak TCP Z forward (writes to PoseZCmdU)     |
+| Control:PoseZTweakRev    | calcout     | Tweak TCP Z backward (writes to PoseZCmdU)     |
+| Control:PoseRollCmd    | ao     | Commanded TCP roll (deg). Does not trigger motion.     |
+| Control:PoseRollCmdU    | ao     | Sets roll target and executes moveL     |
 | Control:PoseRollTweakVal    | ao     | Roll tweak step size     |
-| Control:PoseRollTweakFwd    | bo     | Tweak TCP roll forward     |
-| Control:PoseRollTweakRev    | bo     | Tweak TCP roll backward     |
-| Control:PosePitchCmd    | ao     | Commanded TCP pitch (deg)     |
+| Control:PoseRollTweakFwd    | calcout     | Tweak TCP roll forward (writes to PoseRollCmdU)     |
+| Control:PoseRollTweakRev    | calcout     | Tweak TCP roll backward (writes to PoseRollCmdU)     |
+| Control:PosePitchCmd    | ao     | Commanded TCP pitch (deg). Does not trigger motion.     |
+| Control:PosePitchCmdU    | ao     | Sets pitch target and executes moveL     |
 | Control:PosePitchTweakVal    | ao     | Pitch tweak step size     |
-| Control:PosePitchTweakFwd    | bo     | Tweak TCP pitch forward     |
-| Control:PosePitchTweakRev    | bo     | Tweak TCP pitch backward     |
-| Control:PoseYawCmd    | ao     | Commanded TCP yaw (deg)     |
+| Control:PosePitchTweakFwd    | calcout     | Tweak TCP pitch forward (writes to PosePitchCmdU)     |
+| Control:PosePitchTweakRev    | calcout     | Tweak TCP pitch backward (writes to PosePitchCmdU)     |
+| Control:PoseYawCmd    | ao     | Commanded TCP yaw (deg). Does not trigger motion.     |
+| Control:PoseYawCmdU    | ao     | Sets yaw target and executes moveL     |
 | Control:PoseYawTweakVal    | ao     | Yaw tweak step size     |
-| Control:PoseYawTweakFwd    | bo     | Tweak TCP yaw forward     |
-| Control:PoseYawTweakRev    | bo     | Tweak TCP yaw backward     |
+| Control:PoseYawTweakFwd    | calcout     | Tweak TCP yaw forward (writes to PoseYawCmdU)     |
+| Control:PoseYawTweakRev    | calcout     | Tweak TCP yaw backward (writes to PoseYawCmdU)     |
 | Control:TCPOffset_X    | ao     | TCP offset X (mm)     |
 | Control:TCPOffset_Y    | ao     | TCP offset Y (mm)     |
 | Control:TCPOffset_Z    | ao     | TCP offset Z (mm)     |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,17 +69,28 @@ It also has a button to enable/disable teach (freedrive) mode.
 
 <img src="./assets/GUIs/ui/urRobot_control.png" alt="ui-control" width="600">
 
-Although the default control GUI may look similar to typical EPICS motor screens, the robot's joint are *not* true EPICS motors.
+Although the default control GUI may look similar to typical EPICS motor screens, the robot's joints are *not* true EPICS motors.
 The x, y, z, roll, pitch, and yaw motors are virtual axes and moving them will move one or more joint motors. The joint motors
 themselves are independent of each other, however motion of any joint motor will affect the position of the tool. To reconcile
-this and reduce the likelyhood of accidentally commanding motion you didn't indend, every time motion completes, the command values
+this and reduce the likelihood of accidentally commanding motion you didn't intend, every time motion completes, the command values
 are automatically set to the current readback values, similar to an EPICS motor record.
-The "Go" toggles (which write to the `$(P)Control:AutoMoveJ` or `$(P)Control:AutoMoveL` PVs) are similar to the Go/Move
-options in the EPICS motor record. For example, to move Joint 1 to -75deg, if "Go" is set to "No" (`$(P)Control:AutoMoveJ`=0),
-then you must set Joint 1 to -75deg and click "Move" (`$(P)Control:moveJ`). If "Go" is set to "Yes" (`$(P)Control:AutoMoveJ`=1),
-the robot will begin moving as soon as the commanded values change, so typing -75 in the box for Joint 1 and clicking enter will
-start the robot moving. The same goes for the Cartesian moves. Note that the "Move" buttons tell the robot to move to the current
-joint or cartesian configuration defined by all 6 of the respective target values (J1Cmd, J2cmd... or PoseXCmd, PoseYCmd...).
+
+There are two sets of command PVs for each axis:
+
+- **`J*Cmd` / `Pose*Cmd`** (e.g. `$(P)Control:J1Cmd`, `$(P)Control:PoseXCmd`) are target-only setpoints.
+  Writing to these records updates the target position in the driver but does *not* trigger motion.
+  To actually move the robot, you must separately process `$(P)Control:moveJ` (for joints) or
+  `$(P)Control:moveL` (for Cartesian). This is the intended workflow for scripts, where you want to
+  set all target values first and then trigger a single coordinated move.
+
+- **`J*CmdU` / `Pose*CmdU`** (e.g. `$(P)Control:J1CmdU`, `$(P)Control:PoseXCmdU`) are convenience
+  records intended for GUI use. Writing to a `*CmdU` record sets the corresponding `*Cmd` target
+  *and* automatically triggers `moveJ` or `moveL`. The tweak buttons (forward/reverse) on the GUI
+  also operate through the `*CmdU` records, so tweaking from the GUI triggers motion immediately.
+
+Note that the "Move" buttons tell the robot to move to the current
+joint or Cartesian configuration defined by all 6 of the respective target values (J1Cmd, J2Cmd, ...
+or PoseXCmd, PoseYCmd, ...).
 
 
 ### Safety Event Handling
@@ -413,14 +424,11 @@ from epics import caget, caput
 # IOC prefix
 PREFIX = "MyIOC:"
 
-# disable AutoMoveJ so we need to trigger move PV to start the move
-caput(f"{PREFIX}Control:AutoMoveJ.VAL", 0)
-
 # Get the current joint angles
 angles = caget(f"{PREFIX}Receive:ActualJointPositions.VAL")
 
-# Move all joints +1.0deg
-angles += 1.0;
+# Set all joint targets to current + 1.0 deg
+angles += 1.0
 for i in range(len(angles)):
     caput(f"{PREFIX}Control:J{i+1}Cmd.VAL", angles[i])
 

--- a/urRobotApp/Db/rtde_control.db
+++ b/urRobotApp/Db/rtde_control.db
@@ -166,21 +166,6 @@ record(calcout, "$(P)Control:auto_sync_steady")
     field(OUT, "$(P)Control:sync_both_cmd.PROC")
 }
 
-record(calcout, "$(P)Control:auto_sync_automovej")
-{
-    field(INPA, "$(P)Control:AutoMoveJ.VAL CP NMS")
-    field(CALC, "A")
-    field(OOPT, "Transition To Non-zero")
-    field(OUT, "$(P)Control:sync_joint_cmd.PROC")
-}
-
-record(calcout, "$(P)Control:auto_sync_automovel")
-{
-    field(INPA, "$(P)Control:AutoMoveL.VAL CP NMS")
-    field(CALC, "A")
-    field(OOPT, "Transition To Non-zero")
-    field(OUT, "$(P)Control:sync_pose_cmd.PROC")
-}
 
 record(calcout, "$(P)Control:startup_sync_cmds")
 {
@@ -196,7 +181,7 @@ record(fanout, "$(P)Control:sync_both_cmd")
     field(LNK1, "$(P)Control:sync_pose_cmd")
 }
 
-record(calcout, "$(P)Control:reset_after_async_move")
+record(calcout, "$(P)Control:sync_after_async_move")
 {
     field(INPA, "$(P)Control:AsyncMoveDone CP")
     field(CALC, "A")
@@ -264,55 +249,39 @@ record(bo, "$(P)Control:stopJ")
     field(FLNK, "$(P)Control:sync_both_cmd.PROC")
 }
 
-record(bo, "$(P)Control:AutoMoveJ")
-{
-    field(DESC, "If 1, moveJ runs when JxCmd changes")
-    field(ZNAM, "No")
-    field(ONAM, "Yes")
-    field(VAL, 0)
-}
-
-record(calcout, "$(P)Control:auto_moveJ_calc")
-{
-    field(INPA, "$(P)Control:AutoMoveJ")
-    field(CALC, "A")
-    field(DISV, 1)
-    field(OOPT, "When Non-zero")
-    field(OUT, "$(P)Control:moveJ.PROC")
-}
 
 record(sseq, "$(P)Control:sync_joint_cmd")
 {
     field(PINI, 0)
 
-    field(LNK1, "$(P)Control:auto_moveJ_calc.DISA CA")
+    field(LNK1, "$(P)Control:moveJ.DISA CA")
     field(STR1, "1")
 
     field(DOL2, "$(P)Receive:Joint1")
-    field(LNK2, "$(P)Control:J1Cmd CA")
+    field(LNK2, "$(P)Control:J1CmdU CA")
     field(WAIT2, "After1")
 
     field(DOL3, "$(P)Receive:Joint2")
-    field(LNK3, "$(P)Control:J2Cmd CA")
+    field(LNK3, "$(P)Control:J2CmdU CA")
     field(WAIT3, "After1")
 
     field(DOL4, "$(P)Receive:Joint3")
-    field(LNK4, "$(P)Control:J3Cmd CA")
+    field(LNK4, "$(P)Control:J3CmdU CA")
     field(WAIT4, "After1")
 
     field(DOL5, "$(P)Receive:Joint4")
-    field(LNK5, "$(P)Control:J4Cmd CA")
+    field(LNK5, "$(P)Control:J4CmdU CA")
     field(WAIT5, "After1")
 
     field(DOL6, "$(P)Receive:Joint5")
-    field(LNK6, "$(P)Control:J5Cmd CA")
+    field(LNK6, "$(P)Control:J5CmdU CA")
     field(WAIT6, "After1")
 
     field(DOL7, "$(P)Receive:Joint6")
-    field(LNK7, "$(P)Control:J6Cmd CA")
+    field(LNK7, "$(P)Control:J6CmdU CA")
     field(WAIT7, "After1")
 
-    field(LNK8, "$(P)Control:auto_moveJ_calc.DISA CA")
+    field(LNK8, "$(P)Control:moveJ.DISA CA")
     field(STR8, "0")
     field(WAIT8, "After7")
 }
@@ -327,37 +296,35 @@ record(ao, "$(P)Control:J1Cmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveJ_calc.PROC")
+}
+record(ao, "$(P)Control:J1CmdU")
+{
+    field(DESC, "Sets J1 target and executes moveJ")
+    field(OUT,  "$(P)Control:J1Cmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveJ.PROC")
 }
 record(ao, "$(P)Control:J1TweakVal")
 {
     field(DESC, "Joint 1 tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
 }
-record(bo, "$(P)Control:J1TweakFwd")
+record(calcout, "$(P)Control:J1TweakFwd")
 {
-    field(DESC, "Tweak joint 1 forward")
-    field(FLNK, "$(P)Control:J1TweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:J1TweakRev")
-{
-    field(DESC, "Tweak joint 1 backward")
-    field(FLNK, "$(P)Control:J1TweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:J1TweakCalcFwd")
-{
-    field(INPA, "$(P)Control:J1Cmd")
+    field(INPA, "$(P)Control:J1CmdU.VAL")
     field(INPB, "$(P)Control:J1TweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:J1Cmd PP")
+    field(OUT, "$(P)Control:J1CmdU PP")
 }
-record(calcout, "$(P)Control:J1TweakCalcRev")
+record(calcout, "$(P)Control:J1TweakRev")
 {
-    field(INPA, "$(P)Control:J1Cmd")
+    field(INPA, "$(P)Control:J1CmdU.VAL")
     field(INPB, "$(P)Control:J1TweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:J1Cmd PP")
+    field(OUT, "$(P)Control:J1CmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -370,37 +337,35 @@ record(ao, "$(P)Control:J2Cmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveJ_calc.PROC")
+}
+record(ao, "$(P)Control:J2CmdU")
+{
+    field(DESC, "Sets J2 target and executes moveJ")
+    field(OUT,  "$(P)Control:J2Cmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveJ.PROC")
 }
 record(ao, "$(P)Control:J2TweakVal")
 {
     field(DESC, "Joint 2 tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
 }
-record(bo, "$(P)Control:J2TweakFwd")
+record(calcout, "$(P)Control:J2TweakFwd")
 {
-    field(DESC, "Tweak joint 2 forward")
-    field(FLNK, "$(P)Control:J2TweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:J2TweakRev")
-{
-    field(DESC, "Tweak joint 2 backward")
-    field(FLNK, "$(P)Control:J2TweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:J2TweakCalcFwd")
-{
-    field(INPA, "$(P)Control:J2Cmd")
+    field(INPA, "$(P)Control:J2CmdU.VAL")
     field(INPB, "$(P)Control:J2TweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:J2Cmd PP")
+    field(OUT, "$(P)Control:J2CmdU PP")
 }
-record(calcout, "$(P)Control:J2TweakCalcRev")
+record(calcout, "$(P)Control:J2TweakRev")
 {
-    field(INPA, "$(P)Control:J2Cmd")
+    field(INPA, "$(P)Control:J2CmdU.VAL")
     field(INPB, "$(P)Control:J2TweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:J2Cmd PP")
+    field(OUT, "$(P)Control:J2CmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -413,37 +378,35 @@ record(ao, "$(P)Control:J3Cmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveJ_calc.PROC")
+}
+record(ao, "$(P)Control:J3CmdU")
+{
+    field(DESC, "Sets J3 target and executes moveJ")
+    field(OUT,  "$(P)Control:J3Cmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveJ.PROC")
 }
 record(ao, "$(P)Control:J3TweakVal")
 {
     field(DESC, "Joint 3 tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
 }
-record(bo, "$(P)Control:J3TweakFwd")
+record(calcout, "$(P)Control:J3TweakFwd")
 {
-    field(DESC, "Tweak joint 3 forward")
-    field(FLNK, "$(P)Control:J3TweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:J3TweakRev")
-{
-    field(DESC, "Tweak joint 3 backward")
-    field(FLNK, "$(P)Control:J3TweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:J3TweakCalcFwd")
-{
-    field(INPA, "$(P)Control:J3Cmd")
+    field(INPA, "$(P)Control:J3CmdU.VAL")
     field(INPB, "$(P)Control:J3TweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:J3Cmd PP")
+    field(OUT, "$(P)Control:J3CmdU PP")
 }
-record(calcout, "$(P)Control:J3TweakCalcRev")
+record(calcout, "$(P)Control:J3TweakRev")
 {
-    field(INPA, "$(P)Control:J3Cmd")
+    field(INPA, "$(P)Control:J3CmdU.VAL")
     field(INPB, "$(P)Control:J3TweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:J3Cmd PP")
+    field(OUT, "$(P)Control:J3CmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -456,37 +419,35 @@ record(ao, "$(P)Control:J4Cmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveJ_calc.PROC")
+}
+record(ao, "$(P)Control:J4CmdU")
+{
+    field(DESC, "Sets J4 target and executes moveJ")
+    field(OUT,  "$(P)Control:J4Cmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveJ.PROC")
 }
 record(ao, "$(P)Control:J4TweakVal")
 {
     field(DESC, "Joint 4 tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
 }
-record(bo, "$(P)Control:J4TweakFwd")
+record(calcout, "$(P)Control:J4TweakFwd")
 {
-    field(DESC, "Tweak joint 4 forward")
-    field(FLNK, "$(P)Control:J4TweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:J4TweakRev")
-{
-    field(DESC, "Tweak joint 4 backward")
-    field(FLNK, "$(P)Control:J4TweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:J4TweakCalcFwd")
-{
-    field(INPA, "$(P)Control:J4Cmd")
+    field(INPA, "$(P)Control:J4CmdU.VAL")
     field(INPB, "$(P)Control:J4TweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:J4Cmd PP")
+    field(OUT, "$(P)Control:J4CmdU PP")
 }
-record(calcout, "$(P)Control:J4TweakCalcRev")
+record(calcout, "$(P)Control:J4TweakRev")
 {
-    field(INPA, "$(P)Control:J4Cmd")
+    field(INPA, "$(P)Control:J4CmdU.VAL")
     field(INPB, "$(P)Control:J4TweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:J4Cmd PP")
+    field(OUT, "$(P)Control:J4CmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -499,37 +460,35 @@ record(ao, "$(P)Control:J5Cmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveJ_calc.PROC")
+}
+record(ao, "$(P)Control:J5CmdU")
+{
+    field(DESC, "Sets J5 target and executes moveJ")
+    field(OUT,  "$(P)Control:J5Cmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveJ.PROC")
 }
 record(ao, "$(P)Control:J5TweakVal")
 {
     field(DESC, "Joint 5 tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
 }
-record(bo, "$(P)Control:J5TweakFwd")
+record(calcout, "$(P)Control:J5TweakFwd")
 {
-    field(DESC, "Tweak joint 5 forward")
-    field(FLNK, "$(P)Control:J5TweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:J5TweakRev")
-{
-    field(DESC, "Tweak joint 5 backward")
-    field(FLNK, "$(P)Control:J5TweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:J5TweakCalcFwd")
-{
-    field(INPA, "$(P)Control:J5Cmd")
+    field(INPA, "$(P)Control:J5CmdU.VAL")
     field(INPB, "$(P)Control:J5TweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:J5Cmd PP")
+    field(OUT, "$(P)Control:J5CmdU PP")
 }
-record(calcout, "$(P)Control:J5TweakCalcRev")
+record(calcout, "$(P)Control:J5TweakRev")
 {
-    field(INPA, "$(P)Control:J5Cmd")
+    field(INPA, "$(P)Control:J5CmdU.VAL")
     field(INPB, "$(P)Control:J5TweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:J5Cmd PP")
+    field(OUT, "$(P)Control:J5CmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -542,37 +501,35 @@ record(ao, "$(P)Control:J6Cmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveJ_calc.PROC")
+}
+record(ao, "$(P)Control:J6CmdU")
+{
+    field(DESC, "Sets J6 target and executes moveJ")
+    field(OUT,  "$(P)Control:J6Cmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveJ.PROC")
 }
 record(ao, "$(P)Control:J6TweakVal")
 {
     field(DESC, "Joint 6 tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
 }
-record(bo, "$(P)Control:J6TweakFwd")
+record(calcout, "$(P)Control:J6TweakFwd")
 {
-    field(DESC, "Tweak joint 6 forward")
-    field(FLNK, "$(P)Control:J6TweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:J6TweakRev")
-{
-    field(DESC, "Tweak joint 6 backward")
-    field(FLNK, "$(P)Control:J6TweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:J6TweakCalcFwd")
-{
-    field(INPA, "$(P)Control:J6Cmd")
+    field(INPA, "$(P)Control:J6CmdU.VAL")
     field(INPB, "$(P)Control:J6TweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:J6Cmd PP")
+    field(OUT, "$(P)Control:J6CmdU PP")
 }
-record(calcout, "$(P)Control:J6TweakCalcRev")
+record(calcout, "$(P)Control:J6TweakRev")
 {
-    field(INPA, "$(P)Control:J6Cmd")
+    field(INPA, "$(P)Control:J6CmdU.VAL")
     field(INPB, "$(P)Control:J6TweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:J6Cmd PP")
+    field(OUT, "$(P)Control:J6CmdU PP")
 }
 
 #======================
@@ -624,55 +581,38 @@ record(bo, "$(P)Control:stopL")
     field(FLNK, "$(P)Control:sync_both_cmd.PROC")
 }
 
-record(bo, "$(P)Control:AutoMoveL")
-{
-    field(DESC, "If 1, moveL runs when Cmd changes")
-    field(ZNAM, "No")
-    field(ONAM, "Yes")
-    field(VAL, 0)
-}
-
-record(calcout, "$(P)Control:auto_moveL_calc")
-{
-    field(INPA, "$(P)Control:AutoMoveL")
-    field(CALC, "A")
-    field(DISV, 1)
-    field(OOPT, "When Non-zero")
-    field(OUT, "$(P)Control:moveL.PROC")
-}
-
 record(sseq, "$(P)Control:sync_pose_cmd")
 {
     field(PINI, 0)
 
-    field(LNK1, "$(P)Control:auto_moveL_calc.DISA CA")
+    field(LNK1, "$(P)Control:moveL.DISA CA")
     field(STR1, "1")
 
     field(DOL2, "$(P)Receive:PoseX")
-    field(LNK2, "$(P)Control:PoseXCmd CA")
+    field(LNK2, "$(P)Control:PoseXCmdU CA")
     field(WAIT2, "After1")
 
     field(DOL3, "$(P)Receive:PoseY")
-    field(LNK3, "$(P)Control:PoseYCmd CA")
+    field(LNK3, "$(P)Control:PoseYCmdU CA")
     field(WAIT3, "After1")
 
     field(DOL4, "$(P)Receive:PoseZ")
-    field(LNK4, "$(P)Control:PoseZCmd CA")
+    field(LNK4, "$(P)Control:PoseZCmdU CA")
     field(WAIT4, "After1")
 
     field(DOL5, "$(P)Receive:PoseRoll")
-    field(LNK5, "$(P)Control:PoseRollCmd CA")
+    field(LNK5, "$(P)Control:PoseRollCmdU CA")
     field(WAIT5, "After1")
 
     field(DOL6, "$(P)Receive:PosePitch")
-    field(LNK6, "$(P)Control:PosePitchCmd CA")
+    field(LNK6, "$(P)Control:PosePitchCmdU CA")
     field(WAIT6, "After1")
 
     field(DOL7, "$(P)Receive:PoseYaw")
-    field(LNK7, "$(P)Control:PoseYawCmd CA")
+    field(LNK7, "$(P)Control:PoseYawCmdU CA")
     field(WAIT7, "After1")
 
-    field(LNK8, "$(P)Control:auto_moveL_calc.DISA CA")
+    field(LNK8, "$(P)Control:moveL.DISA CA")
     field(STR8, "0")
     field(WAIT8, "After7")
 }
@@ -681,45 +621,43 @@ record(sseq, "$(P)Control:sync_pose_cmd")
 
 record(ao, "$(P)Control:PoseXCmd")
 {
-    field(DESC, "X")
+    field(DESC, "Commanded TCP X")
     field(DTYP, "asynFloat64")
     field(OUT,  "@asyn($(PORT),0,$(TIMEOUT=1))POSE_CMD")
     field(EGU, "mm")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveL_calc.PROC")
+}
+record(ao, "$(P)Control:PoseXCmdU")
+{
+    field(DESC, "Sets X target and executes moveL")
+    field(OUT,  "$(P)Control:PoseXCmd.VAL PP")
+    field(EGU, "mm")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveL.PROC")
 }
 record(ao, "$(P)Control:PoseXTweakVal")
 {
     field(DESC, "X TCP pose tweak step size")
+    field(VAL, 1)
     field(EGU, "mm")
     field(PREC, 4)
     field(DRVH, "100.0")
     field(DRVL, "0.0")
 }
-record(bo, "$(P)Control:PoseXTweakFwd")
+record(calcout, "$(P)Control:PoseXTweakFwd")
 {
-    field(DESC, "Tweak X TCP pose forward")
-    field(FLNK, "$(P)Control:PoseXTweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:PoseXTweakRev")
-{
-    field(DESC, "Tweak X TCP pose backward")
-    field(FLNK, "$(P)Control:PoseXTweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:PoseXTweakCalcFwd")
-{
-    field(INPA, "$(P)Control:PoseXCmd")
+    field(INPA, "$(P)Control:PoseXCmdU.VAL")
     field(INPB, "$(P)Control:PoseXTweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:PoseXCmd PP")
+    field(OUT, "$(P)Control:PoseXCmdU PP")
 }
-record(calcout, "$(P)Control:PoseXTweakCalcRev")
+record(calcout, "$(P)Control:PoseXTweakRev")
 {
-    field(INPA, "$(P)Control:PoseXCmd")
+    field(INPA, "$(P)Control:PoseXCmdU.VAL")
     field(INPB, "$(P)Control:PoseXTweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:PoseXCmd PP")
+    field(OUT, "$(P)Control:PoseXCmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -732,39 +670,37 @@ record(ao, "$(P)Control:PoseYCmd")
     field(EGU, "mm")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveL_calc.PROC")
+}
+record(ao, "$(P)Control:PoseYCmdU")
+{
+    field(DESC, "Sets Y target and executes moveL")
+    field(OUT,  "$(P)Control:PoseYCmd.VAL PP")
+    field(EGU, "mm")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveL.PROC")
 }
 record(ao, "$(P)Control:PoseYTweakVal")
 {
     field(DESC, "Y TCP pose tweak step size")
+    field(VAL, 1)
     field(EGU, "mm")
     field(PREC, 4)
     field(DRVH, "100")
     field(DRVL, "0.0")
 }
-record(bo, "$(P)Control:PoseYTweakFwd")
+record(calcout, "$(P)Control:PoseYTweakFwd")
 {
-    field(DESC, "Tweak Y TCP pose forward")
-    field(FLNK, "$(P)Control:PoseYTweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:PoseYTweakRev")
-{
-    field(DESC, "Tweak Y TCP pose backward")
-    field(FLNK, "$(P)Control:PoseYTweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:PoseYTweakCalcFwd")
-{
-    field(INPA, "$(P)Control:PoseYCmd")
+    field(INPA, "$(P)Control:PoseYCmdU.VAL")
     field(INPB, "$(P)Control:PoseYTweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:PoseYCmd PP")
+    field(OUT, "$(P)Control:PoseYCmdU PP")
 }
-record(calcout, "$(P)Control:PoseYTweakCalcRev")
+record(calcout, "$(P)Control:PoseYTweakRev")
 {
-    field(INPA, "$(P)Control:PoseYCmd")
+    field(INPA, "$(P)Control:PoseYCmdU.VAL")
     field(INPB, "$(P)Control:PoseYTweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:PoseYCmd PP")
+    field(OUT, "$(P)Control:PoseYCmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -778,39 +714,37 @@ record(ao, "$(P)Control:PoseZCmd")
     field(EGU, "mm")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveL_calc.PROC")
+}
+record(ao, "$(P)Control:PoseZCmdU")
+{
+    field(DESC, "Sets Z target and executes moveL")
+    field(OUT,  "$(P)Control:PoseZCmd.VAL PP")
+    field(EGU, "mm")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveL.PROC")
 }
 record(ao, "$(P)Control:PoseZTweakVal")
 {
     field(DESC, "TCP Z tweak step size")
+    field(VAL, 1)
     field(EGU, "mm")
     field(PREC, 4)
     field(DRVH, "100")
     field(DRVL, "0.0")
 }
-record(bo, "$(P)Control:PoseZTweakFwd")
+record(calcout, "$(P)Control:PoseZTweakFwd")
 {
-    field(DESC, "Tweak TCP Z forward")
-    field(FLNK, "$(P)Control:PoseZTweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:PoseZTweakRev")
-{
-    field(DESC, "Tweak TCP Z backward")
-    field(FLNK, "$(P)Control:PoseZTweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:PoseZTweakCalcFwd")
-{
-    field(INPA, "$(P)Control:PoseZCmd")
+    field(INPA, "$(P)Control:PoseZCmdU.VAL")
     field(INPB, "$(P)Control:PoseZTweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:PoseZCmd PP")
+    field(OUT, "$(P)Control:PoseZCmdU PP")
 }
-record(calcout, "$(P)Control:PoseZTweakCalcRev")
+record(calcout, "$(P)Control:PoseZTweakRev")
 {
-    field(INPA, "$(P)Control:PoseZCmd")
+    field(INPA, "$(P)Control:PoseZCmdU.VAL")
     field(INPB, "$(P)Control:PoseZTweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:PoseZCmd PP")
+    field(OUT, "$(P)Control:PoseZCmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -823,38 +757,36 @@ record(ao, "$(P)Control:PoseRollCmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveL_calc.PROC")
+}
+record(ao, "$(P)Control:PoseRollCmdU")
+{
+    field(DESC, "Sets roll target and executes moveL")
+    field(OUT,  "$(P)Control:PoseRollCmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveL.PROC")
 }
 record(ao, "$(P)Control:PoseRollTweakVal")
 {
     field(DESC, "TCP roll tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
     field(DRVL, "0.0")
 }
-record(bo, "$(P)Control:PoseRollTweakFwd")
+record(calcout, "$(P)Control:PoseRollTweakFwd")
 {
-    field(DESC, "Tweak TCP roll forward")
-    field(FLNK, "$(P)Control:PoseRollTweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:PoseRollTweakRev")
-{
-    field(DESC, "Tweak TCP roll backward")
-    field(FLNK, "$(P)Control:PoseRollTweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:PoseRollTweakCalcFwd")
-{
-    field(INPA, "$(P)Control:PoseRollCmd")
+    field(INPA, "$(P)Control:PoseRollCmdU.VAL")
     field(INPB, "$(P)Control:PoseRollTweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:PoseRollCmd PP")
+    field(OUT, "$(P)Control:PoseRollCmdU PP")
 }
-record(calcout, "$(P)Control:PoseRollTweakCalcRev")
+record(calcout, "$(P)Control:PoseRollTweakRev")
 {
-    field(INPA, "$(P)Control:PoseRollCmd")
+    field(INPA, "$(P)Control:PoseRollCmdU.VAL")
     field(INPB, "$(P)Control:PoseRollTweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:PoseRollCmd PP")
+    field(OUT, "$(P)Control:PoseRollCmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -867,38 +799,36 @@ record(ao, "$(P)Control:PosePitchCmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveL_calc.PROC")
+}
+record(ao, "$(P)Control:PosePitchCmdU")
+{
+    field(DESC, "Sets pitch target and executes moveL")
+    field(OUT,  "$(P)Control:PosePitchCmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveL.PROC")
 }
 record(ao, "$(P)Control:PosePitchTweakVal")
 {
     field(DESC, "TCP pitch tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
     field(DRVL, "0.0")
 }
-record(bo, "$(P)Control:PosePitchTweakFwd")
+record(calcout, "$(P)Control:PosePitchTweakFwd")
 {
-    field(DESC, "Tweak TCP pitch forward")
-    field(FLNK, "$(P)Control:PosePitchTweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:PosePitchTweakRev")
-{
-    field(DESC, "Tweak TCP pitch backward")
-    field(FLNK, "$(P)Control:PosePitchTweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:PosePitchTweakCalcFwd")
-{
-    field(INPA, "$(P)Control:PosePitchCmd")
+    field(INPA, "$(P)Control:PosePitchCmdU.VAL")
     field(INPB, "$(P)Control:PosePitchTweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:PosePitchCmd PP")
+    field(OUT, "$(P)Control:PosePitchCmdU PP")
 }
-record(calcout, "$(P)Control:PosePitchTweakCalcRev")
+record(calcout, "$(P)Control:PosePitchTweakRev")
 {
-    field(INPA, "$(P)Control:PosePitchCmd")
+    field(INPA, "$(P)Control:PosePitchCmdU.VAL")
     field(INPB, "$(P)Control:PosePitchTweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:PosePitchCmd PP")
+    field(OUT, "$(P)Control:PosePitchCmdU PP")
 }
 
 # -----------------------------------------------------------
@@ -911,38 +841,36 @@ record(ao, "$(P)Control:PoseYawCmd")
     field(EGU, "deg")
     field(PINI, 1)
     field(PREC, 4)
-    field(FLNK, "$(P)Control:auto_moveL_calc.PROC")
+}
+record(ao, "$(P)Control:PoseYawCmdU")
+{
+    field(DESC, "Sets yaw target and executes moveL")
+    field(OUT,  "$(P)Control:PoseYawCmd.VAL PP")
+    field(EGU, "deg")
+    field(PREC, 4)
+    field(FLNK, "$(P)Control:moveL.PROC")
 }
 record(ao, "$(P)Control:PoseYawTweakVal")
 {
     field(DESC, "TCP yaw tweak step size")
+    field(VAL, 1)
     field(EGU, "deg")
     field(PREC, 4)
     field(DRVL, "0.0")
 }
-record(bo, "$(P)Control:PoseYawTweakFwd")
+record(calcout, "$(P)Control:PoseYawTweakFwd")
 {
-    field(DESC, "Tweak TCP yaw forward")
-    field(FLNK, "$(P)Control:PoseYawTweakCalcFwd.PROC")
-}
-record(bo, "$(P)Control:PoseYawTweakRev")
-{
-    field(DESC, "Tweak TCP yaw backward")
-    field(FLNK, "$(P)Control:PoseYawTweakCalcRev.PROC")
-}
-record(calcout, "$(P)Control:PoseYawTweakCalcFwd")
-{
-    field(INPA, "$(P)Control:PoseYawCmd")
+    field(INPA, "$(P)Control:PoseYawCmdU.VAL")
     field(INPB, "$(P)Control:PoseYawTweakVal")
     field(CALC, "A + B")
-    field(OUT, "$(P)Control:PoseYawCmd PP")
+    field(OUT, "$(P)Control:PoseYawCmdU PP")
 }
-record(calcout, "$(P)Control:PoseYawTweakCalcRev")
+record(calcout, "$(P)Control:PoseYawTweakRev")
 {
-    field(INPA, "$(P)Control:PoseYawCmd")
+    field(INPA, "$(P)Control:PoseYawCmdU.VAL")
     field(INPB, "$(P)Control:PoseYawTweakVal")
     field(CALC, "A - B")
-    field(OUT, "$(P)Control:PoseYawCmd PP")
+    field(OUT, "$(P)Control:PoseYawCmdU PP")
 }
 
 record(ao, "$(P)Control:TCPOffset_X")

--- a/urRobotApp/op/adl/ur_rtde_control.adl
+++ b/urRobotApp/op/adl/ur_rtde_control.adl
@@ -5,8 +5,8 @@ file {
 }
 display {
 	object {
-		x=710
-		y=514
+		x=1287
+		y=409
 		width=820
 		height=635
 	}
@@ -111,20 +111,6 @@ rectangle {
 		clr=29
 	}
 }
-"choice button" {
-	object {
-		x=50
-		y=240
-		width=80
-		height=20
-	}
-	control {
-		chan="$(P)Control:AutoMoveJ"
-		clr=14
-		bclr=51
-	}
-	stacking="column"
-}
 rectangle {
 	object {
 		x=26
@@ -151,7 +137,7 @@ rectangle {
 }
 "message button" {
 	object {
-		x=145
+		x=550
 		y=240
 		width=50
 		height=20
@@ -172,7 +158,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J1TweakRev"
+		chan="$(P)Control:J1TweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -202,7 +188,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J1TweakFwd"
+		chan="$(P)Control:J1TweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -217,7 +203,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:J1Cmd.VAL"
+		chan="$(P)Control:J1CmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -297,22 +283,9 @@ rectangle {
 text {
 	object {
 		x=20
-		y=240
-		width=30
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-		fill="outline"
-	}
-	textix="Go:"
-}
-text {
-	object {
-		x=20
 		y=205
-		width=100
-		height=20
+		width=150
+		height=25
 	}
 	"basic attribute" {
 		clr=14
@@ -420,7 +393,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J2TweakRev"
+		chan="$(P)Control:J2TweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -450,7 +423,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J2TweakFwd"
+		chan="$(P)Control:J2TweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -465,7 +438,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:J2Cmd.VAL"
+		chan="$(P)Control:J2CmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -600,7 +573,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J3TweakRev"
+		chan="$(P)Control:J3TweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -630,7 +603,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J3TweakFwd"
+		chan="$(P)Control:J3TweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -645,7 +618,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:J3Cmd.VAL"
+		chan="$(P)Control:J3CmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -780,7 +753,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J4TweakRev"
+		chan="$(P)Control:J4TweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -810,7 +783,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J4TweakFwd"
+		chan="$(P)Control:J4TweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -825,7 +798,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:J4Cmd.VAL"
+		chan="$(P)Control:J4CmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -960,7 +933,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J5TweakRev"
+		chan="$(P)Control:J5TweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -990,7 +963,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J5TweakFwd"
+		chan="$(P)Control:J5TweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1005,7 +978,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:J5Cmd.VAL"
+		chan="$(P)Control:J5CmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -1140,7 +1113,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J6TweakRev"
+		chan="$(P)Control:J6TweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1170,7 +1143,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:J6TweakFwd"
+		chan="$(P)Control:J6TweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1185,7 +1158,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:J6Cmd.VAL"
+		chan="$(P)Control:J6CmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -1288,20 +1261,6 @@ text {
 	textix="Joint 6"
 	align="horiz. centered"
 }
-"choice button" {
-	object {
-		x=50
-		y=460
-		width=80
-		height=20
-	}
-	control {
-		chan="$(P)Control:AutoMoveL"
-		clr=14
-		bclr=51
-	}
-	stacking="column"
-}
 rectangle {
 	object {
 		x=26
@@ -1328,7 +1287,7 @@ rectangle {
 }
 "message button" {
 	object {
-		x=140
+		x=550
 		y=460
 		width=50
 		height=20
@@ -1349,7 +1308,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseXTweakRev"
+		chan="$(P)Control:PoseXTweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1379,7 +1338,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseXTweakFwd"
+		chan="$(P)Control:PoseXTweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1394,7 +1353,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:PoseXCmd.VAL"
+		chan="$(P)Control:PoseXCmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -1474,22 +1433,9 @@ rectangle {
 text {
 	object {
 		x=20
-		y=460
-		width=30
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-		fill="outline"
-	}
-	textix="Go:"
-}
-text {
-	object {
-		x=20
 		y=425
-		width=150
-		height=20
+		width=200
+		height=25
 	}
 	"basic attribute" {
 		clr=14
@@ -1568,7 +1514,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseYTweakRev"
+		chan="$(P)Control:PoseYTweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1598,7 +1544,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseYTweakFwd"
+		chan="$(P)Control:PoseYTweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1613,7 +1559,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:PoseYCmd.VAL"
+		chan="$(P)Control:PoseYCmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -1748,7 +1694,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseZTweakRev"
+		chan="$(P)Control:PoseZTweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1778,7 +1724,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseZTweakFwd"
+		chan="$(P)Control:PoseZTweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1793,7 +1739,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:PoseZCmd.VAL"
+		chan="$(P)Control:PoseZCmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -1928,7 +1874,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseRollTweakRev"
+		chan="$(P)Control:PoseRollTweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1958,7 +1904,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseRollTweakFwd"
+		chan="$(P)Control:PoseRollTweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -1973,7 +1919,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:PoseRollCmd.VAL"
+		chan="$(P)Control:PoseRollCmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -2108,7 +2054,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PosePitchTweakRev"
+		chan="$(P)Control:PosePitchTweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -2138,7 +2084,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PosePitchTweakFwd"
+		chan="$(P)Control:PosePitchTweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -2153,7 +2099,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:PosePitchCmd.VAL"
+		chan="$(P)Control:PosePitchCmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -2288,7 +2234,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseYawTweakRev"
+		chan="$(P)Control:PoseYawTweakRev.PROC"
 		clr=14
 		bclr=51
 	}
@@ -2318,7 +2264,7 @@ rectangle {
 		height=20
 	}
 	control {
-		chan="$(P)Control:PoseYawTweakFwd"
+		chan="$(P)Control:PoseYawTweakFwd.PROC"
 		clr=14
 		bclr=51
 	}
@@ -2333,7 +2279,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)Control:PoseYawCmd.VAL"
+		chan="$(P)Control:PoseYawCmdU.VAL"
 		clr=14
 		bclr=51
 	}
@@ -2536,7 +2482,7 @@ text {
 }
 "message button" {
 	object {
-		x=205
+		x=495
 		y=240
 		width=50
 		height=20
@@ -2551,7 +2497,7 @@ text {
 }
 "message button" {
 	object {
-		x=200
+		x=495
 		y=460
 		width=50
 		height=20
@@ -2885,8 +2831,8 @@ text {
 }
 "related display" {
 	object {
-		x=550
-		y=460
+		x=705
+		y=160
 		width=100
 		height=20
 	}
@@ -2898,4 +2844,210 @@ text {
 	clr=0
 	bclr=19
 	label="-TCP Offset"
+}
+"text entry" {
+	object {
+		x=100
+		y=240
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:J1Cmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=25
+		y=240
+		width=70
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+	textix="Target:"
+}
+"text entry" {
+	object {
+		x=165
+		y=240
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:J2Cmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=230
+		y=240
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:J3Cmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=295
+		y=240
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:J4Cmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=360
+		y=240
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:J5Cmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=425
+		y=240
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:J6Cmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+text {
+	object {
+		x=25
+		y=460
+		width=70
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+		fill="outline"
+	}
+	textix="Target:"
+}
+"text entry" {
+	object {
+		x=100
+		y=460
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:PoseXCmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=165
+		y=460
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:PoseYCmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=230
+		y=460
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:PoseZCmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=295
+		y=460
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:PoseRollCmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=360
+		y=460
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:PosePitchCmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=425
+		y=460
+		width=60
+		height=20
+	}
+	control {
+		chan="$(P)Control:PoseYawCmd.VAL"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
 }

--- a/urRobotApp/op/ui/autoconvert/ur_rtde_control.ui
+++ b/urRobotApp/op/ui/autoconvert/ur_rtde_control.ui
@@ -4,8 +4,8 @@
 <widget class="QMainWindow" name="MainWindow">
     <property name="geometry">
         <rect>
-            <x>710</x>
-            <y>514</y>
+            <x>1287</x>
+            <y>409</y>
             <width>820</width>
             <height>635</height>
         </rect>
@@ -183,39 +183,6 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caChoice" name="caChoice_0">
-            <property name="geometry">
-                <rect>
-                    <x>50</x>
-                    <y>240</y>
-                    <width>80</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P)Control:AutoMoveJ</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>115</red>
-                    <green>223</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="stackingMode">
-                <enum>Column</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caChoice::Static</enum>
-            </property>
-        </widget>
         <widget class="caGraphics" name="caRectangle_2">
             <property name="form">
                 <enum>caGraphics::Rectangle</enum>
@@ -291,7 +258,7 @@ caMenu{
         <widget class="caMessageButton" name="caMessageButton_0">
             <property name="geometry">
                 <rect>
-                    <x>145</x>
+                    <x>550</x>
                     <y>240</y>
                     <width>50</width>
                     <height>20</height>
@@ -340,7 +307,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J1TweakRev</string>
+                <string>$(P)Control:J1TweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -430,7 +397,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J1TweakFwd</string>
+                <string>$(P)Control:J1TweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -469,7 +436,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J1Cmd.VAL</string>
+                <string>$(P)Control:J1CmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -750,42 +717,6 @@ caMenu{
                 </color>
             </property>
             <property name="text">
-                <string>Go:</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>20</x>
-                    <y>240</y>
-                    <width>30</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_1">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
                 <string>Joint Move</string>
             </property>
             <property name="fontScaleMode">
@@ -795,15 +726,15 @@ caMenu{
                 <rect>
                     <x>20</x>
                     <y>205</y>
-                    <width>100</width>
-                    <height>20</height>
+                    <width>150</width>
+                    <height>25</height>
                 </rect>
             </property>
             <property name="alignment">
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_2">
+        <widget class="caLabel" name="caLabel_1">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -899,7 +830,7 @@ caMenu{
                 <enum>caSlider::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_3">
+        <widget class="caLabel" name="caLabel_2">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -971,7 +902,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_4">
+        <widget class="caLabel" name="caLabel_3">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1092,7 +1023,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J2TweakRev</string>
+                <string>$(P)Control:J2TweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1182,7 +1113,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J2TweakFwd</string>
+                <string>$(P)Control:J2TweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1221,7 +1152,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J2Cmd.VAL</string>
+                <string>$(P)Control:J2CmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1519,7 +1450,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_5">
+        <widget class="caLabel" name="caLabel_4">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -1640,7 +1571,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J3TweakRev</string>
+                <string>$(P)Control:J3TweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1730,7 +1661,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J3TweakFwd</string>
+                <string>$(P)Control:J3TweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -1769,7 +1700,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J3Cmd.VAL</string>
+                <string>$(P)Control:J3CmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -2067,7 +1998,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_6">
+        <widget class="caLabel" name="caLabel_5">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2188,7 +2119,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J4TweakRev</string>
+                <string>$(P)Control:J4TweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -2278,7 +2209,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J4TweakFwd</string>
+                <string>$(P)Control:J4TweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -2317,7 +2248,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J4Cmd.VAL</string>
+                <string>$(P)Control:J4CmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -2615,7 +2546,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_7">
+        <widget class="caLabel" name="caLabel_6">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -2736,7 +2667,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J5TweakRev</string>
+                <string>$(P)Control:J5TweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -2826,7 +2757,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J5TweakFwd</string>
+                <string>$(P)Control:J5TweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -2865,7 +2796,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J5Cmd.VAL</string>
+                <string>$(P)Control:J5CmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -3163,7 +3094,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_8">
+        <widget class="caLabel" name="caLabel_7">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -3284,7 +3215,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J6TweakRev</string>
+                <string>$(P)Control:J6TweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -3374,7 +3305,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J6TweakFwd</string>
+                <string>$(P)Control:J6TweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -3413,7 +3344,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:J6Cmd.VAL</string>
+                <string>$(P)Control:J6CmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -3711,7 +3642,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_9">
+        <widget class="caLabel" name="caLabel_8">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -3745,39 +3676,6 @@ caMenu{
                     <width>100</width>
                     <height>15</height>
                 </rect>
-            </property>
-        </widget>
-        <widget class="caChoice" name="caChoice_1">
-            <property name="geometry">
-                <rect>
-                    <x>50</x>
-                    <y>460</y>
-                    <width>80</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="channel">
-                <string>$(P)Control:AutoMoveL</string>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="255">
-                    <red>115</red>
-                    <green>223</green>
-                    <blue>255</blue>
-                </color>
-            </property>
-            <property name="stackingMode">
-                <enum>Column</enum>
-            </property>
-            <property name="colorMode">
-                <enum>caChoice::Static</enum>
             </property>
         </widget>
         <widget class="caGraphics" name="caRectangle_38">
@@ -3855,7 +3753,7 @@ caMenu{
         <widget class="caMessageButton" name="caMessageButton_13">
             <property name="geometry">
                 <rect>
-                    <x>140</x>
+                    <x>550</x>
                     <y>460</y>
                     <width>50</width>
                     <height>20</height>
@@ -3904,7 +3802,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseXTweakRev</string>
+                <string>$(P)Control:PoseXTweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -3994,7 +3892,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseXTweakFwd</string>
+                <string>$(P)Control:PoseXTweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -4033,7 +3931,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseXCmd.VAL</string>
+                <string>$(P)Control:PoseXCmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -4295,43 +4193,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_10">
-            <property name="frameShape">
-                <enum>QFrame::NoFrame</enum>
-            </property>
-            <property name="foreground">
-                <color alpha="255">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="background">
-                <color alpha="0">
-                    <red>0</red>
-                    <green>0</green>
-                    <blue>0</blue>
-                </color>
-            </property>
-            <property name="text">
-                <string>Go:</string>
-            </property>
-            <property name="fontScaleMode">
-                <enum>ESimpleLabel::WidthAndHeight</enum>
-            </property>
-            <property name="geometry">
-                <rect>
-                    <x>20</x>
-                    <y>460</y>
-                    <width>30</width>
-                    <height>20</height>
-                </rect>
-            </property>
-            <property name="alignment">
-                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-        </widget>
-        <widget class="caLabel" name="caLabel_11">
+        <widget class="caLabel" name="caLabel_9">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -4359,8 +4221,8 @@ caMenu{
                 <rect>
                     <x>20</x>
                     <y>425</y>
-                    <width>150</width>
-                    <height>20</height>
+                    <width>200</width>
+                    <height>25</height>
                 </rect>
             </property>
             <property name="alignment">
@@ -4443,7 +4305,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_12">
+        <widget class="caLabel" name="caLabel_10">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -4564,7 +4426,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseYTweakRev</string>
+                <string>$(P)Control:PoseYTweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -4654,7 +4516,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseYTweakFwd</string>
+                <string>$(P)Control:PoseYTweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -4693,7 +4555,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseYCmd.VAL</string>
+                <string>$(P)Control:PoseYCmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -4991,7 +4853,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_13">
+        <widget class="caLabel" name="caLabel_11">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -5112,7 +4974,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseZTweakRev</string>
+                <string>$(P)Control:PoseZTweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -5202,7 +5064,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseZTweakFwd</string>
+                <string>$(P)Control:PoseZTweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -5241,7 +5103,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseZCmd.VAL</string>
+                <string>$(P)Control:PoseZCmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -5539,7 +5401,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_14">
+        <widget class="caLabel" name="caLabel_12">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -5660,7 +5522,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseRollTweakRev</string>
+                <string>$(P)Control:PoseRollTweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -5750,7 +5612,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseRollTweakFwd</string>
+                <string>$(P)Control:PoseRollTweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -5789,7 +5651,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseRollCmd.VAL</string>
+                <string>$(P)Control:PoseRollCmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -6087,7 +5949,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_15">
+        <widget class="caLabel" name="caLabel_13">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -6208,7 +6070,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PosePitchTweakRev</string>
+                <string>$(P)Control:PosePitchTweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -6298,7 +6160,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PosePitchTweakFwd</string>
+                <string>$(P)Control:PosePitchTweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -6337,7 +6199,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PosePitchCmd.VAL</string>
+                <string>$(P)Control:PosePitchCmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -6635,7 +6497,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_16">
+        <widget class="caLabel" name="caLabel_14">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -6756,7 +6618,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseYawTweakRev</string>
+                <string>$(P)Control:PoseYawTweakRev.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -6846,7 +6708,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseYawTweakFwd</string>
+                <string>$(P)Control:PoseYawTweakFwd.PROC</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -6885,7 +6747,7 @@ caMenu{
                 <enum>caLineEdit::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:PoseYawCmd.VAL</string>
+                <string>$(P)Control:PoseYawCmdU.VAL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -7183,7 +7045,7 @@ caMenu{
                 <enum>Solid</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_17">
+        <widget class="caLabel" name="caLabel_15">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7375,7 +7237,7 @@ caMenu{
                 <enum>caMessageButton::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_18">
+        <widget class="caLabel" name="caLabel_16">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7420,7 +7282,7 @@ caMenu{
                 </rect>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_19">
+        <widget class="caLabel" name="caLabel_17">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7468,7 +7330,7 @@ caMenu{
         <widget class="caMessageButton" name="caMessageButton_30">
             <property name="geometry">
                 <rect>
-                    <x>205</x>
+                    <x>495</x>
                     <y>240</y>
                     <width>50</width>
                     <height>20</height>
@@ -7507,7 +7369,7 @@ caMenu{
         <widget class="caMessageButton" name="caMessageButton_31">
             <property name="geometry">
                 <rect>
-                    <x>200</x>
+                    <x>495</x>
                     <y>460</y>
                     <width>50</width>
                     <height>20</height>
@@ -7543,7 +7405,7 @@ caMenu{
                 <enum>caMessageButton::Static</enum>
             </property>
         </widget>
-        <widget class="caChoice" name="caChoice_2">
+        <widget class="caChoice" name="caChoice_0">
             <property name="geometry">
                 <rect>
                     <x>210</x>
@@ -7576,7 +7438,7 @@ caMenu{
                 <enum>caChoice::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_20">
+        <widget class="caLabel" name="caLabel_18">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7651,7 +7513,7 @@ caMenu{
                 <enum>caMessageButton::Static</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_21">
+        <widget class="caLabel" name="caLabel_19">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7696,7 +7558,7 @@ caMenu{
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_22">
+        <widget class="caLabel" name="caLabel_20">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7741,7 +7603,7 @@ caMenu{
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_23">
+        <widget class="caLabel" name="caLabel_21">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7786,7 +7648,7 @@ caMenu{
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_24">
+        <widget class="caLabel" name="caLabel_22">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7831,7 +7693,7 @@ caMenu{
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_25">
+        <widget class="caLabel" name="caLabel_23">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7876,7 +7738,7 @@ caMenu{
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_26">
+        <widget class="caLabel" name="caLabel_24">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -7921,7 +7783,7 @@ caMenu{
                 <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_27">
+        <widget class="caLabel" name="caLabel_25">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -8009,7 +7871,7 @@ caMenu{
                 <string>$(P)Control:Moving</string>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_28">
+        <widget class="caLabel" name="caLabel_26">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -8147,7 +8009,7 @@ caMenu{
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_29">
+        <widget class="caLabel" name="caLabel_27">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -8183,7 +8045,7 @@ caMenu{
                 </rect>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_30">
+        <widget class="caLabel" name="caLabel_28">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -8321,7 +8183,7 @@ caMenu{
                 <enum>decimal</enum>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_31">
+        <widget class="caLabel" name="caLabel_29">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -8357,7 +8219,7 @@ caMenu{
                 </rect>
             </property>
         </widget>
-        <widget class="caLabel" name="caLabel_32">
+        <widget class="caLabel" name="caLabel_30">
             <property name="frameShape">
                 <enum>QFrame::NoFrame</enum>
             </property>
@@ -8438,8 +8300,8 @@ caMenu{
         <widget class="caRelatedDisplay" name="caRelatedDisplay_1">
             <property name="geometry">
                 <rect>
-                    <x>550</x>
-                    <y>460</y>
+                    <x>705</x>
+                    <y>160</y>
                     <width>100</width>
                     <height>20</height>
                 </rect>
@@ -8477,6 +8339,690 @@ caMenu{
                 <string>false</string>
             </property>
         </widget>
+        <widget class="caTextEntry" name="caTextEntry_28">
+            <property name="geometry">
+                <rect>
+                    <x>100</x>
+                    <y>240</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:J1Cmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_31">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Target:</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>25</x>
+                    <y>240</y>
+                    <width>70</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_29">
+            <property name="geometry">
+                <rect>
+                    <x>165</x>
+                    <y>240</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:J2Cmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_30">
+            <property name="geometry">
+                <rect>
+                    <x>230</x>
+                    <y>240</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:J3Cmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_31">
+            <property name="geometry">
+                <rect>
+                    <x>295</x>
+                    <y>240</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:J4Cmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_32">
+            <property name="geometry">
+                <rect>
+                    <x>360</x>
+                    <y>240</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:J5Cmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_33">
+            <property name="geometry">
+                <rect>
+                    <x>425</x>
+                    <y>240</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:J6Cmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caLabel" name="caLabel_32">
+            <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="0">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="text">
+                <string>Target:</string>
+            </property>
+            <property name="fontScaleMode">
+                <enum>ESimpleLabel::WidthAndHeight</enum>
+            </property>
+            <property name="geometry">
+                <rect>
+                    <x>25</x>
+                    <y>460</y>
+                    <width>70</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="alignment">
+                <set>Qt::AlignAbsolute|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_34">
+            <property name="geometry">
+                <rect>
+                    <x>100</x>
+                    <y>460</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:PoseXCmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_35">
+            <property name="geometry">
+                <rect>
+                    <x>165</x>
+                    <y>460</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:PoseYCmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_36">
+            <property name="geometry">
+                <rect>
+                    <x>230</x>
+                    <y>460</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:PoseZCmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_37">
+            <property name="geometry">
+                <rect>
+                    <x>295</x>
+                    <y>460</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:PoseRollCmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_38">
+            <property name="geometry">
+                <rect>
+                    <x>360</x>
+                    <y>460</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:PosePitchCmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
+        <widget class="caTextEntry" name="caTextEntry_39">
+            <property name="geometry">
+                <rect>
+                    <x>425</x>
+                    <y>460</y>
+                    <width>60</width>
+                    <height>20</height>
+                </rect>
+            </property>
+            <property name="fontScaleMode">
+                <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="channel">
+                <string>$(P)Control:PoseYawCmd.VAL</string>
+            </property>
+            <property name="foreground">
+                <color alpha="255">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                </color>
+            </property>
+            <property name="background">
+                <color alpha="255">
+                    <red>115</red>
+                    <green>223</green>
+                    <blue>255</blue>
+                </color>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="precisionMode">
+                <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="minValue">
+                <double>0.0</double>
+            </property>
+            <property name="maxValue">
+                <double>1.0</double>
+            </property>
+            <property name="colorMode">
+                <enum>caLineEdit::Static</enum>
+            </property>
+            <property name="formatType">
+                <enum>decimal</enum>
+            </property>
+        </widget>
         <zorder>caRectangle_0</zorder>
         <zorder>caRectangle_1</zorder>
         <zorder>caRectangle_2</zorder>
@@ -8487,88 +9033,88 @@ caMenu{
         <zorder>caLabel_0</zorder>
         <zorder>caLabel_1</zorder>
         <zorder>caLabel_2</zorder>
-        <zorder>caLabel_3</zorder>
         <zorder>caRectangle_7</zorder>
-        <zorder>caLabel_4</zorder>
+        <zorder>caLabel_3</zorder>
         <zorder>caRectangle_8</zorder>
         <zorder>caRectangle_9</zorder>
         <zorder>caRectangle_10</zorder>
         <zorder>caRectangle_11</zorder>
         <zorder>caRectangle_12</zorder>
         <zorder>caRectangle_13</zorder>
-        <zorder>caLabel_5</zorder>
+        <zorder>caLabel_4</zorder>
         <zorder>caRectangle_14</zorder>
         <zorder>caRectangle_15</zorder>
         <zorder>caRectangle_16</zorder>
         <zorder>caRectangle_17</zorder>
         <zorder>caRectangle_18</zorder>
         <zorder>caRectangle_19</zorder>
-        <zorder>caLabel_6</zorder>
+        <zorder>caLabel_5</zorder>
         <zorder>caRectangle_20</zorder>
         <zorder>caRectangle_21</zorder>
         <zorder>caRectangle_22</zorder>
         <zorder>caRectangle_23</zorder>
         <zorder>caRectangle_24</zorder>
         <zorder>caRectangle_25</zorder>
-        <zorder>caLabel_7</zorder>
+        <zorder>caLabel_6</zorder>
         <zorder>caRectangle_26</zorder>
         <zorder>caRectangle_27</zorder>
         <zorder>caRectangle_28</zorder>
         <zorder>caRectangle_29</zorder>
         <zorder>caRectangle_30</zorder>
         <zorder>caRectangle_31</zorder>
-        <zorder>caLabel_8</zorder>
+        <zorder>caLabel_7</zorder>
         <zorder>caRectangle_32</zorder>
         <zorder>caRectangle_33</zorder>
         <zorder>caRectangle_34</zorder>
         <zorder>caRectangle_35</zorder>
         <zorder>caRectangle_36</zorder>
         <zorder>caRectangle_37</zorder>
-        <zorder>caLabel_9</zorder>
+        <zorder>caLabel_8</zorder>
         <zorder>caRectangle_38</zorder>
         <zorder>caRectangle_39</zorder>
         <zorder>caRectangle_40</zorder>
         <zorder>caRectangle_41</zorder>
         <zorder>caRectangle_42</zorder>
-        <zorder>caLabel_10</zorder>
-        <zorder>caLabel_11</zorder>
+        <zorder>caLabel_9</zorder>
         <zorder>caRectangle_43</zorder>
         <zorder>caRectangle_44</zorder>
-        <zorder>caLabel_12</zorder>
+        <zorder>caLabel_10</zorder>
         <zorder>caRectangle_45</zorder>
         <zorder>caRectangle_46</zorder>
         <zorder>caRectangle_47</zorder>
         <zorder>caRectangle_48</zorder>
         <zorder>caRectangle_49</zorder>
         <zorder>caRectangle_50</zorder>
-        <zorder>caLabel_13</zorder>
+        <zorder>caLabel_11</zorder>
         <zorder>caRectangle_51</zorder>
         <zorder>caRectangle_52</zorder>
         <zorder>caRectangle_53</zorder>
         <zorder>caRectangle_54</zorder>
         <zorder>caRectangle_55</zorder>
         <zorder>caRectangle_56</zorder>
-        <zorder>caLabel_14</zorder>
+        <zorder>caLabel_12</zorder>
         <zorder>caRectangle_57</zorder>
         <zorder>caRectangle_58</zorder>
         <zorder>caRectangle_59</zorder>
         <zorder>caRectangle_60</zorder>
         <zorder>caRectangle_61</zorder>
         <zorder>caRectangle_62</zorder>
-        <zorder>caLabel_15</zorder>
+        <zorder>caLabel_13</zorder>
         <zorder>caRectangle_63</zorder>
         <zorder>caRectangle_64</zorder>
         <zorder>caRectangle_65</zorder>
         <zorder>caRectangle_66</zorder>
         <zorder>caRectangle_67</zorder>
         <zorder>caRectangle_68</zorder>
-        <zorder>caLabel_16</zorder>
+        <zorder>caLabel_14</zorder>
         <zorder>caRectangle_69</zorder>
         <zorder>caRectangle_70</zorder>
         <zorder>caRectangle_71</zorder>
         <zorder>caRectangle_72</zorder>
         <zorder>caRectangle_73</zorder>
         <zorder>caRectangle_74</zorder>
+        <zorder>caLabel_15</zorder>
+        <zorder>caLabel_16</zorder>
         <zorder>caLabel_17</zorder>
         <zorder>caLabel_18</zorder>
         <zorder>caLabel_19</zorder>
@@ -8578,15 +9124,14 @@ caMenu{
         <zorder>caLabel_23</zorder>
         <zorder>caLabel_24</zorder>
         <zorder>caLabel_25</zorder>
+        <zorder>caRectangle_75</zorder>
         <zorder>caLabel_26</zorder>
         <zorder>caLabel_27</zorder>
-        <zorder>caRectangle_75</zorder>
         <zorder>caLabel_28</zorder>
         <zorder>caLabel_29</zorder>
         <zorder>caLabel_30</zorder>
         <zorder>caLabel_31</zorder>
         <zorder>caLabel_32</zorder>
-        <zorder>caChoice_0</zorder>
         <zorder>caMessageButton_0</zorder>
         <zorder>caMessageButton_1</zorder>
         <zorder>caTextEntry_0</zorder>
@@ -8625,7 +9170,6 @@ caMenu{
         <zorder>caTextEntry_11</zorder>
         <zorder>caLineEdit_10</zorder>
         <zorder>caLineEdit_11</zorder>
-        <zorder>caChoice_1</zorder>
         <zorder>caMessageButton_13</zorder>
         <zorder>caMessageButton_14</zorder>
         <zorder>caTextEntry_12</zorder>
@@ -8669,7 +9213,7 @@ caMenu{
         <zorder>caMessageButton_29</zorder>
         <zorder>caMessageButton_30</zorder>
         <zorder>caMessageButton_31</zorder>
-        <zorder>caChoice_2</zorder>
+        <zorder>caChoice_0</zorder>
         <zorder>caMessageButton_32</zorder>
         <zorder>caTextEntry_24</zorder>
         <zorder>caTextEntry_25</zorder>
@@ -8677,6 +9221,18 @@ caMenu{
         <zorder>caTextEntry_27</zorder>
         <zorder>caRelatedDisplay_0</zorder>
         <zorder>caRelatedDisplay_1</zorder>
+        <zorder>caTextEntry_28</zorder>
+        <zorder>caTextEntry_29</zorder>
+        <zorder>caTextEntry_30</zorder>
+        <zorder>caTextEntry_31</zorder>
+        <zorder>caTextEntry_32</zorder>
+        <zorder>caTextEntry_33</zorder>
+        <zorder>caTextEntry_34</zorder>
+        <zorder>caTextEntry_35</zorder>
+        <zorder>caTextEntry_36</zorder>
+        <zorder>caTextEntry_37</zorder>
+        <zorder>caTextEntry_38</zorder>
+        <zorder>caTextEntry_39</zorder>
     </widget>
 </widget>
 </ui>


### PR DESCRIPTION
AutoMoveJ/L switches made things complicated and potentially dangerous when interacting with PVs from a script. This PR replaces the AutoMoveJ and AutoMoveL logic with separate records named J1CmdU...J6CmdU and PoseXCmdU...PoseYawCmdU which are intended to be used from the GUI. These records will write their values to the real J1Cmd.VAL, PoseXCmd.VAL etc. records and then also process moveJ/moveL. J1Cmd itself will only set the target position. The *CmdU records likely should only ever be used from the GUI.