### PR TITLE
Use busy records for ease of synchronous programming

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -414,25 +414,37 @@ After configuring the action, assign it to a waypoint by setting the waypoint's
 
 ## Python Scripting
 
-Below an example Python script using [PyEpics](https://github.com/pyepics/pyepics) is provided which demonstrates how to move
-all six joints by +1.0deg.
-
+Below is an example Python script using [PyEpics](https://github.com/pyepics/pyepics).
 
 ```python
 from epics import caget, caput
 
 # IOC prefix
-PREFIX = "MyIOC:"
+P = "urExample:"
+
+# Helper function to set target joint angles and execute move
+def move_joints(q, wait=True):
+    for i in range(len(q)):
+        caput(f"{P}Control:J{i+1}Cmd.VAL", q[i])
+    caput(f"{P}Control:moveJ", 1, wait=wait)
 
 # Get the current joint angles
-angles = caget(f"{PREFIX}Receive:ActualJointPositions.VAL")
+angles = caget(f"{P}Receive:ActualJointPositions")
 
-# Set all joint targets to current + 1.0 deg
-angles += 1.0
-for i in range(len(angles)):
-    caput(f"{PREFIX}Control:J{i+1}Cmd.VAL", angles[i])
 
-# Execute the move
-caput(f"{PREFIX}Control:moveJ.PROC", 1)
+# Now we run though a simple program.
+# Each line waits for motion to finish before proceeding.
+
+# Move all joints +5deg
+move_joints(angles+5.0)
+
+# Close gripper
+caput(f"{P}RobotiqGripper:Close", 1, wait=True)
+
+# Move joints back to starting positions
+move_joints(angles)
+
+# Open gripper
+caput(f"{P}RobotiqGripper:Open", 1, wait=True)
 ```
 

--- a/urRobotApp/Db/robotiq_gripper.db
+++ b/urRobotApp/Db/robotiq_gripper.db
@@ -83,14 +83,14 @@ record(bo, "$(P)RobotiqGripper:AutoCalibrate")
     field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))AUTO_CALIBRATE")
 }
 
-record(bo, "$(P)RobotiqGripper:Open")
+record(busy, "$(P)RobotiqGripper:Open")
 {
     field(DESC, "Opens Robotiq gripper")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))OPEN")
 }
 
-record(bo, "$(P)RobotiqGripper:Close")
+record(busy, "$(P)RobotiqGripper:Close")
 {
     field(DESC, "Close Robotiq gripper")
     field(DTYP, "asynInt32")
@@ -152,6 +152,20 @@ record(longin, "$(P)RobotiqGripper:MoveStatusRaw")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))MOVE_STATUS")
     field(SCAN, "I/O Intr")
+    field(FLNK, "$(P)RobotiqGripper:clear_busy_calc.PROC")
+}
+
+record(calcout, "$(P)RobotiqGripper:clear_busy_calc") {
+    field(INPA, "$(P)RobotiqGripper:MoveStatusRaw")
+    field(OOPT, "Transition To Non-zero")
+    field(CALC, "A != 0")
+    field(OUT, "$(P)RobotiqGripper:clear_busy.PROC")
+}
+
+record(dfanout, "$(P)RobotiqGripper:clear_busy") {
+    field(DOL, 0)
+    field(OUTA, "$(P)RobotiqGripper:Open PP")
+    field(OUTB, "$(P)RobotiqGripper:Close PP")
 }
 
 record(ai, "$(P)RobotiqGripper:CurrentPosition")

--- a/urRobotApp/Db/rtde_control.db
+++ b/urRobotApp/Db/rtde_control.db
@@ -193,7 +193,7 @@ record(calcout, "$(P)Control:sync_after_async_move")
 # Joint control
 #======================
 
-record(bo, "$(P)Control:moveJ")
+record(busy, "$(P)Control:moveJ")
 {
     field(DESC, "Moves joints to commanded values")
     field(DTYP, "asynInt32")
@@ -536,7 +536,7 @@ record(calcout, "$(P)Control:J6TweakRev")
 # TCP pose control
 #======================
 
-record(bo, "$(P)Control:moveL")
+record(busy, "$(P)Control:moveL")
 {
     field(DESC, "Move to TCP pose linearly")
     field(DTYP, "asynInt32")

--- a/urRobotApp/op/adl/robotiq_gripper.adl
+++ b/urRobotApp/op/adl/robotiq_gripper.adl
@@ -106,7 +106,7 @@ rectangle {
 		height=25
 	}
 	control {
-		chan="$(P)RobotiqGripper:Open.PROC"
+		chan="$(P)RobotiqGripper:Open"
 		clr=14
 		bclr=51
 	}
@@ -149,7 +149,7 @@ text {
 		height=25
 	}
 	control {
-		chan="$(P)RobotiqGripper:Close.PROC"
+		chan="$(P)RobotiqGripper:Close"
 		clr=14
 		bclr=51
 	}

--- a/urRobotApp/op/adl/ur_rtde_control.adl
+++ b/urRobotApp/op/adl/ur_rtde_control.adl
@@ -1948,7 +1948,7 @@ text {
 		height=20
 	}
 	control {
-		chan="$(P)Control:moveJ.PROC"
+		chan="$(P)Control:moveJ"
 		clr=14
 		bclr=51
 	}
@@ -1963,7 +1963,7 @@ text {
 		height=20
 	}
 	control {
-		chan="$(P)Control:moveL.PROC"
+		chan="$(P)Control:moveL"
 		clr=14
 		bclr=51
 	}

--- a/urRobotApp/op/ui/autoconvert/robotiq_gripper.ui
+++ b/urRobotApp/op/ui/autoconvert/robotiq_gripper.ui
@@ -156,7 +156,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)RobotiqGripper:Open.PROC</string>
+                <string>$(P)RobotiqGripper:Open</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -285,7 +285,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)RobotiqGripper:Close.PROC</string>
+                <string>$(P)RobotiqGripper:Close</string>
             </property>
             <property name="foreground">
                 <color alpha="255">

--- a/urRobotApp/op/ui/autoconvert/ur_rtde_control.ui
+++ b/urRobotApp/op/ui/autoconvert/ur_rtde_control.ui
@@ -5696,7 +5696,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:moveJ.PROC</string>
+                <string>$(P)Control:moveJ</string>
             </property>
             <property name="foreground">
                 <color alpha="255">
@@ -5735,7 +5735,7 @@ caMenu{
                 <enum>EPushButton::WidthAndHeight</enum>
             </property>
             <property name="channel">
-                <string>$(P)Control:moveL.PROC</string>
+                <string>$(P)Control:moveL</string>
             </property>
             <property name="foreground">
                 <color alpha="255">

--- a/urRobotApp/src/gripper_driver.cpp
+++ b/urRobotApp/src/gripper_driver.cpp
@@ -218,11 +218,31 @@ asynStatus URGripper::writeInt32(asynUser* pasynUser, epicsInt32 value) {
             spdlog::debug("Activating gripper");
             gripper_->activate();
         } else if (function == openIndex_) {
-            spdlog::debug("Opening gripper");
-            gripper_->open();
+            if (value == 1) {
+                setIntegerParam(openIndex_, 1);
+                const bool is_open = gripper_->isOpen();
+                const bool stopped_outer = gripper_->objectDetectionStatus() == ur_rtde::RobotiqGripper::eObjectStatus::STOPPED_OUTER_OBJECT;
+                if (is_open || stopped_outer) {
+                    spdlog::warn("Gripper already open or stopped at outer object");
+                    setIntegerParam(openIndex_, 0);
+                } else {
+                    spdlog::debug("Opening gripper");
+                    gripper_->open();
+                }
+            }
         } else if (function == closeIndex_) {
-            spdlog::debug("Closing gripper");
-            gripper_->close();
+            if (value == 1) {
+                setIntegerParam(closeIndex_, 1);
+                const bool is_closed = gripper_->isClosed();
+                const bool stopped_inner = gripper_->objectDetectionStatus() == ur_rtde::RobotiqGripper::eObjectStatus::STOPPED_INNER_OBJECT;
+                if (is_closed || stopped_inner) {
+                    spdlog::warn("Gripper already closed or stopped at inner object");
+                    setIntegerParam(closeIndex_, 0);
+                } else {
+                    spdlog::debug("Closing gripper");
+                    gripper_->close();
+                }
+            }
         } else if (function == setPositionRangeIndex_) {
             int minpos = 0;
             int maxpos = 0;

--- a/urRobotApp/src/rtde_control_driver.cpp
+++ b/urRobotApp/src/rtde_control_driver.cpp
@@ -445,11 +445,14 @@ asynStatus RTDEControl::writeInt32(asynUser* pasynUser, epicsInt32 value) {
                 pending_motion_ = MotionTask{MotionType::Joint, waypoint_move_};
                 waypoint_move_ = false;
                 setIntegerParam(asyncMoveDoneIndex_, 0);
+                setIntegerParam(moveJIndex_, 1);
             } else {
                 spdlog::warn("Requested joint angles not within safety limits. No action taken.");
+                setIntegerParam(moveJIndex_, 0);
             }
         } else {
             spdlog::warn("Motion already in progress...please wait");
+            setIntegerParam(moveJIndex_, 0);
         }
     }
 
@@ -460,11 +463,14 @@ asynStatus RTDEControl::writeInt32(asynUser* pasynUser, epicsInt32 value) {
                 pending_motion_ = MotionTask{MotionType::Cartesian, waypoint_move_};
                 waypoint_move_ = false;
                 setIntegerParam(asyncMoveDoneIndex_, 0);
+                setIntegerParam(moveLIndex_, 1);
             } else {
                 spdlog::warn("Requested TCP pose not within safety limits. No action taken.");
+                setIntegerParam(moveLIndex_, 0);
             }
         } else {
             spdlog::warn("Motion already in progress...please wait");
+            setIntegerParam(moveLIndex_, 0);
         }
     }
 

--- a/urRobotApp/src/rtde_control_driver.hpp
+++ b/urRobotApp/src/rtde_control_driver.hpp
@@ -108,6 +108,8 @@ class RTDEControl : public asynPortDriver {
         setIntegerParam(asyncMoveDoneIndex_, 1);
         setIntegerParam(motionDoneCountIndex_, ++motion_done_count_);
         pending_motion_.reset();
+        setIntegerParam(moveJIndex_, 0);
+        setIntegerParam(moveLIndex_, 0);
     }
 
   protected:


### PR DESCRIPTION
This PR changes the `bo` records used to start asynchronous motion (`$(P)Control:moveJ`, `$(P)Control:moveL`, and `$(P)RobotiqGripper:Open` and `$(P)RobotiqGripper:Close`) to `busy` records. This was primarily done so that clients can easily execute robot motion synchronously. Some minor changes to the driver code was also required to support this

With `caput` from the command line, the following will now block until motion completes:
```
caput -w 10 -c urExample:Control:moveJ 1
```
Previously this would return immediately regardless, and clients needed to poll the `$(P)Control:Moving` PV to wait for the motion to complete.


Similarly with `pyepics` you can now do the following to block until motion is complete:
```python
epics.caput("urExample:Control:moveJ", 1, wait=True)
```

In the future I plan to implement this same style of `busy` record logic with the waypoint motion PVs. Once this is completed, it is likely the built in path logic can be fully replaced by `sseq` records with "Wait" options. However, I believe most users will be more interested in simple scripting for robot motion versus building paths from combinations of `sseq`, `calcout`, etc. records at runtime. 